### PR TITLE
Update coordinator url default/parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,10 +42,17 @@ my_project.submit_job(vlr_job)
 
 ### Prerequisites
 
-* Python 3.6 or above, and pip
+* Python 3.6+
+* [pip](https://pip.pypa.io/en/stable/installing/)
 * [Make](https://www.gnu.org/software/make/) (if installing from source)
 
 ### Install via pip
+We recommend that you use a [Python "Virtual Environment"](https://packaging.python.org/tutorials/installing-packages/#creating-virtual-environments) when running applications with `pycape`.
+
+Also ensure that your developement enviroment can access the Python Package Index (PyPI) via https.
+
+Once you've activated your virtual enviroment, use pip
+
 ```sh
 $ pip install pycape
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -42,12 +42,17 @@ See our example [usage](/libraries/pycape/usage/) or a more in-depth [tutorial](
 ## Installation 
 
 ### Prerequisites
-
-* Python 3.6 or above, and pip
-* [Make](https://www.gnu.org/software/make/) (if installing from source)
+* Python 3.6+
+* [pip](https://pip.pypa.io/en/stable/installing/)
 
 ### Install via pip
-```shell
+We recommend that you use a [Python "Virtual Environment"](https://packaging.python.org/tutorials/installing-packages/#creating-virtual-environments) when running applications with `pycape`.
+
+Also ensure that your developement enviroment can access the Python Package Index (PyPI) via https.
+
+Once you've activated your virtual enviroment, use `pip` to install pycape and it's dependencies:
+
+```sh
 $ pip install pycape
 ```
 

--- a/docs/tutorials/submit_linear_regression_job.md
+++ b/docs/tutorials/submit_linear_regression_job.md
@@ -153,7 +153,7 @@ You'll also need to specify the [S3 Bucket location that you would like Cape to 
 >>>     model_owner="org_123",
 >>> )
 
->>> my_project.submit_job(job=vlr)
+>>> my_project.submit_job(vlr)
 ```
 
 You can specify which data columns the model should be trained on or evaluated against by passing the dataview to the [`VerticallyPartitionedLinearRegression`](/libraries/pycape/reference#pycapeverticallypartitionedlinearregression) class like so:

--- a/docs/tutorials/submit_linear_regression_job.md
+++ b/docs/tutorials/submit_linear_regression_job.md
@@ -51,6 +51,10 @@ That is it for the UI for now! We'll return later to review `DataViews` and appr
 Next we will set up these `DataViews` and `Jobs` in `pycape`.
 
 ## Working with the PyCape Python Library
+**pycape** is a set of Python modules for interacting with your Cape Privacy data.
+
+First, [install `pycape`](/libraries/pycape/#installation).
+
 ### Login to PyCape
 
 Before you can make requests to Cape Cloud, you'll need to authenticate with the API. Follow [these instructions to authenticate](/libraries/pycape/usage/login) with our API using `pycape`. Once you've logged in successfully, you should see a success message.

--- a/docs/usage/job.md
+++ b/docs/usage/job.md
@@ -14,7 +14,7 @@ vlr = VerticallyPartitionedLinearRegression(
     model_location="s3://my-bucket"
     model_owner="org_123",
 )
-my_project.submit_job(job=vlr)
+my_project.submit_job(vlr)
 ```
 
 Default response:

--- a/docs/usage/login.md
+++ b/docs/usage/login.md
@@ -2,7 +2,7 @@
 
 To use **`pycape`**, you'll need to generate a [user token](/understand/features/tokens/). You'll use this token to authenticate requests to Cape Cloud.
 
-After setting up an account in [Cape](https://demo.capeprivacy.com), ensure you are
+After setting up an account in [Cape](https://app.capeprivacy.com), ensure you are
 working within your user context and navigate to _Account Settings_ to generate a user token.
 
 ![](../img/user-token.gif)

--- a/examples/linear_regression/README.md
+++ b/examples/linear_regression/README.md
@@ -9,7 +9,7 @@ the beginnings of your project.
 
 To run a linear regression task, you must have two orgs to partake in the computation.
 
-You can create an org using [cape-ui](https://github.com/capeprivacy/cape-ui) or your account on [demo.capeprivacy.com](https://demo.capeprivacy.com)
+You can create an org using [cape-ui](https://github.com/capeprivacy/cape-ui) or your account on [app.capeprivacy.com](https://app.capeprivacy.com)
 
 ![](../img/create_org.gif)
 

--- a/pycape/api/job/job.py
+++ b/pycape/api/job/job.py
@@ -7,7 +7,7 @@ import numpy as np
 
 from ...exceptions import StorageSchemeException
 from ...network.requester import Requester
-from ...utils import setup_boto_file_weights
+from ...utils import setup_boto_file
 
 
 class Job(ABC):
@@ -102,7 +102,11 @@ class Job(ABC):
             raise StorageSchemeException(scheme=p.scheme)
 
         tf = tempfile.NamedTemporaryFile()
-        file_name = setup_boto_file_weights(uri=p, temp_file_name=tf.name)
+        file_name = setup_boto_file(
+            uri=p,
+            temp_file_name=tf.name,
+            download_path=p.path.lstrip("/") + "/regression_weights.csv",
+        )
 
         # return the weights (decoded to np) & metrics
         return np.loadtxt(file_name, delimiter=","), metrics

--- a/pycape/exceptions.py
+++ b/pycape/exceptions.py
@@ -2,6 +2,14 @@ class GQLException(Exception):
     pass
 
 
+class NotAUserException(Exception):
+    pass
+
+
+class InvalidCoordinatorException(Exception):
+    pass
+
+
 class StorageSchemeException(Exception):
     def __init__(self, scheme: str, message: str = None, payload: str = None):
         self.message = message or f"Only s3 locations supported, got {scheme or 'None'}"

--- a/pycape/network/requester.py
+++ b/pycape/network/requester.py
@@ -1,5 +1,6 @@
 import os
 from typing import Optional
+from urllib.parse import urlparse
 
 import requests
 
@@ -40,9 +41,9 @@ class Requester:
 
     def __init__(self, endpoint: str = None):
         self.endpoint = endpoint or os.environ.get(
-            "CAPE_COORDINATOR", "https://demo.capeprivacy.com"
-        ).rstrip("/")
-        self.gql_endpoint = self.endpoint + "/v1/query"
+            "CAPE_COORDINATOR", "https://app.capeprivacy.com"
+        )
+        self.gql_endpoint = f"{urlparse(self.endpoint).scheme}://{urlparse(self.endpoint).netloc}/v1/query"
 
         self.session = requests.Session()
 

--- a/pycape/utils.py
+++ b/pycape/utils.py
@@ -30,22 +30,15 @@ def filter_date(string: str) -> datetime:
     return date
 
 
-def setup_boto_file(uri: pathlib.PosixPath, temp_file_name: str) -> str:
+def setup_boto_file(
+    uri: pathlib.PosixPath, temp_file_name: str, download_path: str = None
+) -> str:
+    if not download_path:
+        download_path = uri.path.lstrip("/")
     # tell boto3 we are pulling from s3, p.netloc will be the bucket
     b = boto3.resource(uri.scheme).Bucket(uri.netloc)
 
     # save the weights for this job in a temp file
-    b.download_file(uri.path.lstrip("/"), temp_file_name)
-
-    return temp_file_name
-
-
-def setup_boto_file_weights(uri: pathlib.PosixPath, temp_file_name: str) -> str:
-    # tell boto3 we are pulling from s3, p.netloc will be the bucket
-    b = boto3.resource(uri.scheme).Bucket(uri.netloc)
-
-    print(uri.path.lstrip("/") + "/regression_weights.csv")
-    # save the weights for this job in a temp file
-    b.download_file(uri.path.lstrip("/") + "/regression_weights.csv", temp_file_name)
+    b.download_file(download_path, temp_file_name)
 
     return temp_file_name

--- a/pycape/utils.py
+++ b/pycape/utils.py
@@ -38,7 +38,6 @@ def setup_boto_file(
     # tell boto3 we are pulling from s3, p.netloc will be the bucket
     b = boto3.resource(uri.scheme).Bucket(uri.netloc)
 
-    # save the weights for this job in a temp file
     b.download_file(download_path, temp_file_name)
 
     return temp_file_name

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pycape"
-version = "0.5.2"
+version = "0.5.3"
 description = "A set of Python modules for interacting with your Cape Privacy data."
 authors = ["Cape Privacy <contact@capeprivacy.com>"]
 license = "Apache-2.0"


### PR DESCRIPTION
- Default coordinator endpoint is now app.capeprivacy.com
- Coordinator url passed via environment variable is now parsed using `urllib.urlparse`
- Docs updated to specifically state that environment installing pycape needs access to PyPI
- Docs also updated to recommend creating a virtual enviroment