### PR TITLE
Remove b64 from input

### DIFF
--- a/pycape/enclave_encrypt.py
+++ b/pycape/enclave_encrypt.py
@@ -1,5 +1,3 @@
-import base64
-
 from tink import BinaryKeysetReader
 from tink import hybrid
 from tink import read_no_secret_keyset_handle

--- a/pycape/enclave_encrypt.py
+++ b/pycape/enclave_encrypt.py
@@ -11,5 +11,4 @@ def encrypt(input_bytes, public_key, context=b""):
     khPub = read_no_secret_keyset_handle(reader)
     encrypt = khPub.primitive(hybrid.HybridEncrypt)
     ciphertext = encrypt.encrypt(input_bytes, context)
-    encoded = base64.b64encode(ciphertext).decode("utf-8")
-    return encoded
+    return ciphertext

--- a/pycape/enclave_encrypt_test.py
+++ b/pycape/enclave_encrypt_test.py
@@ -20,8 +20,7 @@ class TestEnclaveEncryption:
         public_key_stream = io.BytesIO()
         writer = tink.BinaryKeysetWriter(public_key_stream)
         cleartext_keyset_handle.write(writer, public_keyset_handle)
-        ciphertext_b64 = encrypt(plaintext, public_key_stream.getvalue(), context)
-        ciphertext = base64.b64decode(ciphertext_b64.encode("utf-8"))
+        ciphertext = encrypt(plaintext, public_key_stream.getvalue(), context)
         decrypt = private_keyset_handle.primitive(tink.hybrid.HybridDecrypt)
         decrypted_data = decrypt.decrypt(ciphertext, context)
 

--- a/pycape/enclave_encrypt_test.py
+++ b/pycape/enclave_encrypt_test.py
@@ -1,4 +1,3 @@
-import base64
 import io
 
 import tink


### PR DESCRIPTION
Remove b64 from input. The server expects the ciphertext directly 