### PR TITLE
Update pycape import

### DIFF
--- a/examples/main.py
+++ b/examples/main.py
@@ -1,4 +1,4 @@
-from pycape.cape import Cape
+from pycape import Cape
 
 if __name__ == "__main__":
     cape = Cape()

--- a/pycape/__init__.py
+++ b/pycape/__init__.py
@@ -1,0 +1,5 @@
+from pycape.cape import Cape
+
+__all__ = [
+    Cape,
+]

--- a/pycape/cape.py
+++ b/pycape/cape.py
@@ -11,7 +11,6 @@ from pycape.enclave_encrypt import encrypt
 
 class Cape:
     def __init__(self):
-        # self._url = "ws://localhost:8765"
         self._url = "wss://cape.run"
         self._auth_token = "not_implemented"
 


### PR DESCRIPTION
Small PR to be able to import Cape with `from pycape import Cape` instead of `from pycape.cape import Cape`.