### PR TITLE
Gavin/multirun

### DIFF
--- a/examples/main.py
+++ b/examples/main.py
@@ -1,7 +1,8 @@
 from pycape.cape import Cape
 
 if __name__ == "__main__":
-    cape = Cape()
+    cape = Cape(auth_token = "<YOUR_AUTH_TOKEN>")
+
     input = 20
     result = cape.run("c052214b-a597-42fc-9a2f-d48ea9dc9902", input)
     print(f"The result is: {result}")

--- a/examples/multiple_inputs.py
+++ b/examples/multiple_inputs.py
@@ -3,8 +3,8 @@ import asyncio
 
 async def run():
 
-    cape = Cape(auth_token = "<YOUR_AUTH_TOKEN>")
-    
+    cape = Cape(token = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6IlBVMlpQR0d6a3gzbEQzX0JnOUdiRSJ9.eyJpc3MiOiJodHRwczovL21hZXN0cm8tZGV2LnVzLmF1dGgwLmNvbS8iLCJzdWIiOiJnb29nbGUtb2F1dGgyfDExNzUyNjQ3NDY4MTA5ODA2NDMyMyIsImF1ZCI6WyJodHRwczovL25ld2RlbW8uY2FwZXByaXZhY3kuY29tL3YxLyIsImh0dHBzOi8vbWFlc3Ryby1kZXYudXMuYXV0aDAuY29tL3VzZXJpbmZvIl0sImlhdCI6MTY1NTE3NzUyOSwiZXhwIjoxNjU1MjYzOTI5LCJhenAiOiJ5UW5vYmtPcjFwdmREQXlYd05vamtOVjJJUGJOZlh4eCIsInNjb3BlIjoib3BlbmlkIHByb2ZpbGUgZW1haWwifQ.PTVOqxY9EjSaU1FhdcsCMIZpHEv0ouMpw7aN631hXjdRctFfi-7uLhpFOT1E_ZuQHt7U9RmposbVME0Yq_6fyv14Rk4nBtNNRvl-1x28IuETV-6Ix5YHjo1X1oEnMWJ2_X-m8P_82dvxVWHmeAt9Qigt0KK0Y62_P-i6DrJMxbGOJzvF4_3tVOP65CFhCrPphnDik3q7L9RTdmjI7uatgRbAJiINJE4zAjuF6bzOPhYPOdW6SOJXuGrOu0ZyXtQW4bHEpyNJZQ2OpeTP2jm6PPoHXK5xjftKddFOgIoNKjjXQ6c9KKxczkhi1tgoXN_DD3z9JuplAZUYO4tf9j97Uw")
+
     await cape.connect("e4c2a674-9c7f-42d3-8ade-63791c16c3c7")
 
     result = await cape.invoke('Hello Cape')

--- a/examples/multiple_inputs.py
+++ b/examples/multiple_inputs.py
@@ -3,8 +3,11 @@ import asyncio
 
 async def run():
 
-    cape = Cape(token = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6IlBVMlpQR0d6a3gzbEQzX0JnOUdiRSJ9.eyJpc3MiOiJodHRwczovL21hZXN0cm8tZGV2LnVzLmF1dGgwLmNvbS8iLCJzdWIiOiJnb29nbGUtb2F1dGgyfDExNzUyNjQ3NDY4MTA5ODA2NDMyMyIsImF1ZCI6WyJodHRwczovL25ld2RlbW8uY2FwZXByaXZhY3kuY29tL3YxLyIsImh0dHBzOi8vbWFlc3Ryby1kZXYudXMuYXV0aDAuY29tL3VzZXJpbmZvIl0sImlhdCI6MTY1NTE3NzUyOSwiZXhwIjoxNjU1MjYzOTI5LCJhenAiOiJ5UW5vYmtPcjFwdmREQXlYd05vamtOVjJJUGJOZlh4eCIsInNjb3BlIjoib3BlbmlkIHByb2ZpbGUgZW1haWwifQ.PTVOqxY9EjSaU1FhdcsCMIZpHEv0ouMpw7aN631hXjdRctFfi-7uLhpFOT1E_ZuQHt7U9RmposbVME0Yq_6fyv14Rk4nBtNNRvl-1x28IuETV-6Ix5YHjo1X1oEnMWJ2_X-m8P_82dvxVWHmeAt9Qigt0KK0Y62_P-i6DrJMxbGOJzvF4_3tVOP65CFhCrPphnDik3q7L9RTdmjI7uatgRbAJiINJE4zAjuF6bzOPhYPOdW6SOJXuGrOu0ZyXtQW4bHEpyNJZQ2OpeTP2jm6PPoHXK5xjftKddFOgIoNKjjXQ6c9KKxczkhi1tgoXN_DD3z9JuplAZUYO4tf9j97Uw")
+    token = os.environ["CAPE_TOKEN"]
+    url = os.environ.get("CAPE_HOST", "wss://cape.run")
 
+    cape = Cape(url=url, token=token)
+    
     await cape.connect("e4c2a674-9c7f-42d3-8ade-63791c16c3c7")
 
     result = await cape.invoke('Hello Cape')

--- a/examples/multiple_inputs.py
+++ b/examples/multiple_inputs.py
@@ -1,5 +1,6 @@
 from pycape.cape import Cape
 import asyncio
+import os
 
 async def run():
 
@@ -7,7 +8,7 @@ async def run():
     url = os.environ.get("CAPE_HOST", "wss://cape.run")
 
     cape = Cape(url=url, token=token)
-    
+
     await cape.connect("e4c2a674-9c7f-42d3-8ade-63791c16c3c7")
 
     result = await cape.invoke('Hello Cape')

--- a/examples/multiple_inputs.py
+++ b/examples/multiple_inputs.py
@@ -1,6 +1,8 @@
-from pycape.cape import Cape
 import asyncio
 import os
+
+from pycape.cape import Cape
+
 
 async def run():
 
@@ -11,16 +13,17 @@ async def run():
 
     await cape.connect("e4c2a674-9c7f-42d3-8ade-63791c16c3c7")
 
-    result = await cape.invoke('Hello Cape')
+    result = await cape.invoke("Hello Cape")
     print(f"The result is: {result}")
 
-    result = await cape.invoke('Hello Gavin')
+    result = await cape.invoke("Hello Gavin")
     print(f"The result is: {result}")
 
-    result = await cape.invoke('Hello Hello')
+    result = await cape.invoke("Hello Hello")
     print(f"The result is: {result}")
 
     await cape.close()
+
 
 if __name__ == "__main__":
     asyncio.run(run())

--- a/examples/multiple_inputs.py
+++ b/examples/multiple_inputs.py
@@ -1,0 +1,22 @@
+from pycape.cape import Cape
+import asyncio
+
+async def run():
+
+    cape = Cape(auth_token = "<YOUR_AUTH_TOKEN>")
+    
+    await cape.connect("e4c2a674-9c7f-42d3-8ade-63791c16c3c7")
+
+    result = await cape.invoke('Hello Cape')
+    print(f"The result is: {result}")
+
+    result = await cape.invoke('Hello Gavin')
+    print(f"The result is: {result}")
+
+    result = await cape.invoke('Hello Hello')
+    print(f"The result is: {result}")
+
+    await cape.close()
+
+if __name__ == "__main__":
+    asyncio.run(run())

--- a/pycape/cape.py
+++ b/pycape/cape.py
@@ -66,6 +66,7 @@ class Cape:
 
         return result
 
+
 # TODO What should be the length?
 def _generate_nonce(length=8):
     return "".join([str(random.randint(0, 9)) for i in range(length)])


### PR DESCRIPTION
Decouples the connection (`cape.connect`) from the invocation (`cape.invoke`) so developers can run their function multiple times over a single connection

`cape.run` now wraps connect and invoke.

