### PR TITLE
Load access token from .config and remove insecure arg to Cape client

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ make install
 
 ## Usage
 
-Before running a function, you need to first get an access token (`<AUTH_TOKEN>`) with the [Cape CLI](https://github.com/capeprivacy/cli) by running `cape login`. Once logged into Cape, you can find the access token in your `~/.config` directory as follows: `cat ~/.config/cape/auth`. Then you'll obtain a function id ('<FUNCTION_ID>') once you have deployed your function with `cape deploy`.
+Before running a function, you need to first get an access token (`<AUTH_TOKEN>`) with the [Cape CLI](https://github.com/capeprivacy/cli) by running `cape login`. Once logged into Cape, your can be found in the `~/.config/cape/auth` file. Then you'll obtain a function id ('<FUNCTION_ID>') once you have deployed a function with `cape deploy`.
 
 ### `run`
 
@@ -44,7 +44,7 @@ Example [run.py](https://github.com/capeprivacy/pycape/tree/main/examples/run.py
 ```py
 from pycape import Cape
 
-client = Cape(token='<AUTH_TOKEN>')
+client = Cape()
 client.run(function_id='<FUNCTION_ID>', input='my_data')
 ```
 
@@ -57,7 +57,7 @@ Example [invoke.py](https://github.com/capeprivacy/pycape/blob/main/examples/inv
 ```py
 from pycape import Cape
 
-client = Cape(token='<AUTH_TOKEN>')
+client = Cape()
 client.connect(function_id='<FUNCTION_ID>')
 client.invoke(input='my-data-1')
 client.invoke(input='my-data-2')

--- a/examples/invoke.py
+++ b/examples/invoke.py
@@ -3,7 +3,7 @@ import os
 from pycape.cape import Cape
 
 if __name__ == "__main__":
-    token = os.environ["CAPE_TOKEN"]
+    token = os.environ.get("CAPE_TOKEN", None)
     url = os.environ.get("CAPE_HOST", "wss://cape.run")
     cape = Cape(url=url, token=token)
     function_id = os.environ.get(

--- a/examples/run.py
+++ b/examples/run.py
@@ -3,7 +3,7 @@ import os
 from pycape import Cape
 
 if __name__ == "__main__":
-    token = os.environ["CAPE_TOKEN"]
+    token = os.environ.get("CAPE_TOKEN", None)
     url = os.environ.get("CAPE_HOST", "wss://cape.run")
     function_id = os.environ.get(
         "CAPE_FUNCTION", "e4c2a674-9c7f-42d3-8ade-63791c16c3c7"

--- a/pycape/cape.py
+++ b/pycape/cape.py
@@ -1,6 +1,7 @@
 import asyncio
 import base64
 import json
+import os
 import pathlib
 import random
 import ssl
@@ -11,16 +12,16 @@ from pycape.attestation import parse_attestation
 from pycape.enclave_encrypt import encrypt
 
 _CAPE_CONFIG_PATH = pathlib.Path.home() / ".config" / "cape"
+_DISABLE_SSL = os.environ.get("CAPEDEV_DISABLE_SSL", False)
 
 
 class Cape:
-    def __init__(self, url="wss://cape.run", access_token=None, insecure=False):
+    def __init__(self, url="wss://cape.run", access_token=None):
         self._url = url
         if access_token is None:
             cape_auth_path = _CAPE_CONFIG_PATH / "auth"
             access_token = _handle_default_auth(cape_auth_path)
         self._auth_token = access_token
-        self._insecure = insecure
         self._websocket = ""
         self._public_key = ""
         self._loop = asyncio.get_event_loop()
@@ -42,7 +43,7 @@ class Cape:
 
         ctx = ssl.create_default_context()
 
-        if self._insecure:
+        if _DISABLE_SSL:
             ctx.check_hostname = False
             ctx.verify_mode = ssl.CERT_NONE
 


### PR DESCRIPTION
Load access token from `~/.config/cape/auth` if token not explicitly provided when instantiating Cape client.
Renames `token` param to `access_token` in Cape client constructor.
Allow for disabling SSL through an env variable `CAPEDEV_DISABLE_SSL`, removes `insecure` param to Cape client constructor.

CAPE-627
CAPE-586