### PR TITLE
Fix examples

### DIFF
--- a/examples/invoke.py
+++ b/examples/invoke.py
@@ -5,7 +5,7 @@ from pycape.cape import Cape
 if __name__ == "__main__":
     token = os.environ.get("CAPE_TOKEN", None)
     url = os.environ.get("CAPE_HOST", "wss://cape.run")
-    cape = Cape(url=url, token=token)
+    cape = Cape(url=url, access_token=token)
     function_id = os.environ.get(
         "CAPE_FUNCTION", "e4c2a674-9c7f-42d3-8ade-63791c16c3c7"
     )

--- a/examples/run.py
+++ b/examples/run.py
@@ -9,7 +9,7 @@ if __name__ == "__main__":
         "CAPE_FUNCTION", "e4c2a674-9c7f-42d3-8ade-63791c16c3c7"
     )
 
-    cape = Cape(url=url, token=token)
+    cape = Cape(url=url, access_token=token)
     input = "Welcome to Cape"
     result = cape.run(function_id, input)
 


### PR DESCRIPTION
`token` weren't rename to `access_token` in examples