### PR TITLE
raise errors from message responses

### DIFF
--- a/pycape/cape.py
+++ b/pycape/cape.py
@@ -134,19 +134,19 @@ def _create_connection_request(token, nonce):
 
 def _parse_attestation_response(result):
     result = json.loads(result)
-    if 'error' in result:
-        raise Exception(result['error'])
+    if "error" in result:
+        raise Exception(result["error"])
 
-    return result['message']
+    return result["message"]
 
 
 def _parse_websocket_result(result):
     result = json.loads(result)
-    if 'error' in result:
-        raise Exception(result['error'])
+    if "error" in result:
+        raise Exception(result["error"])
 
-    msg = result['message']
-    data = base64.b64decode(msg['message'])
+    msg = result["message"]
+    data = base64.b64decode(msg["message"])
     return data
 
 

--- a/pycape/cape.py
+++ b/pycape/cape.py
@@ -75,7 +75,7 @@ class Cape:
         await self._websocket.send(request)
 
         msg = await self._websocket.recv()
-        attestation_doc = json.loads(msg)["message"]
+        attestation_doc = _parse_attestation_response(msg)
         doc = base64.b64decode(attestation_doc["message"])
         self._public_key = attest.parse_attestation(doc, download_root_cert())
 
@@ -132,10 +132,21 @@ def _create_connection_request(token, nonce):
     return json.dumps(request)
 
 
+def _parse_attestation_response(result):
+    result = json.loads(result)
+    if 'error' in result:
+        raise Exception(result['error'])
+
+    return result['message']
+
+
 def _parse_websocket_result(result):
-    result = json.loads(result)["message"]
-    b64data = result["message"]
-    data = base64.b64decode(b64data)
+    result = json.loads(result)
+    if 'error' in result:
+        raise Exception(result['error'])
+
+    msg = result['message']
+    data = base64.b64decode(msg['message'])
     return data
 
 


### PR DESCRIPTION
example stack trace from passing a string to isprime

```
$ python run_echo.py
Traceback (most recent call last):
  File "run_echo.py", line 15, in <module>
    result = cape.run(function_id, input)
  File "/Users/bendecoste/code/pycape/pycape/cape.py", line 52, in run
    return asyncio.run(
  File "/Applications/Xcode.app/Contents/Developer/Library/Frameworks/Python3.framework/Versions/3.8/lib/python3.8/asyncio/runners.py", line 44, in run
    return loop.run_until_complete(main)
  File "/Applications/Xcode.app/Contents/Developer/Library/Frameworks/Python3.framework/Versions/3.8/lib/python3.8/asyncio/base_events.py", line 616, in run_until_complete
    return future.result()
  File "/Users/bendecoste/code/pycape/pycape/cape.py", line 118, in _run
    result = await self._invoke(input, serde_hooks, msgpack_serialize)
  File "/Users/bendecoste/code/pycape/pycape/cape.py", line 104, in _invoke
    result = _parse_websocket_result(result)
  File "/Users/bendecoste/code/pycape/pycape/cape.py", line 146, in _parse_websocket_result
    raise Exception(result['error'])
Exception: failed to run function due to: exit status 1: trace sudo: unable to resolve host (none): Name or service not known
>>> CALLING APP <<<
ERROR ENCOUNTERED: invalid literal for int() with base 10: b'hey!'
traceback:
Traceback (most recent call last):
  File "/home/jailuser/functions/WnSffQiZNMv2FCZtFWxdVp/isprime/launch.py", line 22, in main
    results = app.cape_handler(input_data)
  File "/home/jailuser/functions/WnSffQiZNMv2FCZtFWxdVp/isprime/app.py", line 15, in cape_handler
    n = int(arg)
ValueError: invalid literal for int() with base 10: b'hey!'

>>> DONE CALLING APP <<<


```