### PR TITLE
Clean-up of Cape client and attestation functions

### DIFF
--- a/pycape/attestation.py
+++ b/pycape/attestation.py
@@ -75,7 +75,7 @@ def verify_cert_chain(root_cert, cabundle, cert):
     logger.debug("* Attestation certificate chain verified.")
 
 
-def verify_attestation_signature(payload, cert) -> bool:
+def verify_attestation_signature(payload, cert):
     logger.debug("* Verifying attestation certificate signature...")
     cert = load_der_x509_certificate(cert)
     cert_public_numbers = cert.public_key().public_numbers()

--- a/pycape/attestation.py
+++ b/pycape/attestation.py
@@ -1,57 +1,56 @@
+import io
 import logging
 import math
+import zipfile
 
 import cbor2
+import requests
 from cose.keys import EC2Key
 from cose.keys.curves import P384
 from cose.messages import Sign1Message
 from cryptography.x509 import load_der_x509_certificate
 from OpenSSL import crypto
 
+_AWS_ROOT_CERT_ARCHIVE = (
+    "https://aws-nitro-enclaves.amazonaws.com/AWS_NitroEnclaves_Root-G1.zip"
+)
+
 logger = logging.getLogger("pycape")
 
 
+def download_root_cert():
+    logger.debug(
+        f"* Downloading AWS root cert for attestation from {_AWS_ROOT_CERT_ARCHIVE}..."
+    )
+    r = requests.get(_AWS_ROOT_CERT_ARCHIVE)
+    f = zipfile.ZipFile(io.BytesIO(r.content))
+    with f.open("root.pem") as p:
+        root_cert = p.read()
+    logger.debug("AWS root cert received.")
+    return root_cert
+
+
 def parse_attestation(attestation, root_cert):
-    logger.debug("\n* Verifying attestation document")
+    logger.debug("* Parsing attestation document...")
     # TODO verifies the PCRs
     payload = cbor2.loads(attestation)
     doc = cbor2.loads(payload[2])
+    _check_wellformed_attestation(
+        doc,
+        expected_keys=["certificate", "cabundle", "public_key"],
+    )
+    doc_cert = doc["certificate"]
+    cabundle = doc["cabundle"]
+    public_key = doc["public_key"]
+    logger.debug("* Attestation document parsed.")
 
-    logger.debug("* Verifying signature")
-    if not verify_signature(attestation, doc["certificate"]):
-        raise ValueError("wrong signature")
-
-    logger.debug("* Verifying certificate chain")
-    verify_cert_chain(root_cert, doc["cabundle"], doc["certificate"])
-
-    public_key = doc.get("public_key")
-    if public_key is None:
-        raise ValueError("The public key is missing in the attestation document.")
-
+    verify_attestation_signature(attestation, doc_cert)
+    verify_cert_chain(root_cert, cabundle, doc_cert)
     return public_key
 
 
-def verify_signature(payload, cert) -> bool:
-    cert = load_der_x509_certificate(cert)
-    cert_public_numbers = cert.public_key().public_numbers()
-    x = cert_public_numbers.x
-    y = cert_public_numbers.y
-
-    x = _long_to_bytes(x)
-    y = _long_to_bytes(y)
-
-    # Create the EC2 key from public key parameters
-    key = EC2Key(x=x, y=y, crv=P384)
-
-    cose_obj = cbor2.loads(payload)
-    msg = Sign1Message.from_cose_obj(cose_obj, allow_unknown_attributes=True)
-    msg.key = key
-
-    # Verify the signature using the EC2 key
-    return msg.verify_signature()
-
-
 def verify_cert_chain(root_cert, cabundle, cert):
+    logger.debug("* Verifying attestation certificate chain...")
     cert = crypto.load_certificate(crypto.FILETYPE_ASN1, cert)
 
     # Create an X509Store object for the CA bundles
@@ -73,8 +72,46 @@ def verify_cert_chain(root_cert, cabundle, cert):
     # Validate the certificate
     # If the cert is invalid, it will raise exception
     store_ctx.verify_certificate()
+    logger.debug("* Attestation certificate chain verified.")
+
+
+def verify_attestation_signature(payload, cert) -> bool:
+    logger.debug("* Verifying attestation certificate signature...")
+    cert = load_der_x509_certificate(cert)
+    cert_public_numbers = cert.public_key().public_numbers()
+    x = cert_public_numbers.x
+    y = cert_public_numbers.y
+
+    x = _long_to_bytes(x)
+    y = _long_to_bytes(y)
+
+    # Create the EC2 key from public key parameters
+    key = EC2Key(x=x, y=y, crv=P384)
+
+    cose_obj = cbor2.loads(payload)
+    msg = Sign1Message.from_cose_obj(cose_obj, allow_unknown_attributes=True)
+    msg.key = key
+
+    # Verify the signature using the EC2 key
+    verified = msg.verify_signature()
+    if not verified:
+        errmsg = "Malformed attestation doc: incorrect certificate signature."
+        logger.error(errmsg)
+        raise RuntimeError(errmsg)
+    logger.debug("* Attestation certificate signature verified.")
 
 
 def _long_to_bytes(x: int):
     bytesize = math.ceil(x.bit_length() / 8.0)
     return x.to_bytes(bytesize, byteorder="big")
+
+
+def _check_wellformed_attestation(doc, expected_keys):
+    for doc_key in expected_keys:
+        if doc_key not in doc:
+            errmsg = (
+                "Malformed attestation doc: missing attestation "
+                f"document field {doc_key}."
+            )
+            logger.error(errmsg)
+            raise RuntimeError(errmsg)

--- a/pycape/attestation_test.py
+++ b/pycape/attestation_test.py
@@ -17,9 +17,7 @@ from cryptography.hazmat.primitives.asymmetric import ec
 from cryptography.hazmat.primitives.serialization import Encoding
 from cryptography.x509.oid import NameOID
 
-from pycape.attestation import parse_attestation
-from pycape.attestation import verify_cert_chain
-from pycape.attestation import verify_signature
+from pycape import attestation as attest
 
 
 class TestAttestation:
@@ -34,12 +32,12 @@ class TestAttestation:
         doc_bytes = create_attestation_doc(root_cert, cert)
         attestation = create_cose_1_sign_msg(doc_bytes, private_key)
 
-        public_key = parse_attestation(
+        public_key = attest.parse_attestation(
             attestation, root_cert.public_bytes(Encoding.PEM)
         )
         assert len(public_key) == 32
 
-    def test_verify_signature(self):
+    def test_verify_attestation_signature(self):
         crv = P384
         root_private_key = ec.generate_private_key(
             crv.curve_obj, backend=default_backend()
@@ -53,7 +51,7 @@ class TestAttestation:
         payload = cbor2.loads(attestation)
         doc = cbor2.loads(payload[2])
 
-        verify_signature(attestation, doc["certificate"])
+        attest.verify_attestation_signature(attestation, doc["certificate"])
 
     def test_verify_cert_chain(self):
         crv = P384
@@ -76,7 +74,7 @@ class TestAttestation:
         with f.open("root.pem") as p:
             root_cert = p.read()
 
-        verify_cert_chain(root_cert, doc["cabundle"], doc["certificate"])
+        attest.verify_cert_chain(root_cert, doc["cabundle"], doc["certificate"])
 
 
 def create_cose_1_sign_msg(payload, private_key):

--- a/pycape/cape.py
+++ b/pycape/cape.py
@@ -1,15 +1,12 @@
 import asyncio
 import base64
-import io
 import json
 import logging
 import os
 import pathlib
 import random
 import ssl
-import zipfile
 
-import requests
 import websockets
 
 from pycape import attestation as attest
@@ -35,6 +32,7 @@ class Cape:
         self._auth_token = access_token
         self._websocket = ""
         self._public_key = ""
+        self._root_cert = None
         self._loop = asyncio.get_event_loop()
 
         if verbose:
@@ -81,18 +79,17 @@ class Cape:
         logger.debug("* Websocket connection established")
 
         nonce = _generate_nonce()
-        logger.debug(f"* Generated nonce: {nonce}")
         request = _create_connection_request(self._auth_token, nonce)
 
-        logger.debug("\n> Sending nonce and auth token")
+        logger.debug("\n> Sending auth request...")
         await self._websocket.send(request)
 
         logger.debug("* Waiting for attestation document...")
         msg = await self._websocket.recv()
-        logger.debug("< Auth completed. received attestation document")
-        attestation_doc = _parse_attestation_response(msg)
-        doc = base64.b64decode(attestation_doc["message"])
-        self._public_key = attest.parse_attestation(doc, download_root_cert())
+        logger.debug("< Auth completed. Received attestation document.")
+        attestation_doc = _parse_wss_response(msg)
+        self._root_cert = self._root_cert or attest.download_root_cert()
+        self._public_key = attest.parse_attestation(attestation_doc, self._root_cert)
 
         return
 
@@ -112,14 +109,13 @@ class Cape:
                 "with MessagePack."
             )
 
-        logger.debug("\n* Encrypting inputs with Hybrid Public Key Encryption (HPKE)")
         input_ciphertext = enclave_encrypt.encrypt(self._public_key, input)
 
-        logger.debug("\n> Sending encrypted inputs")
+        logger.debug("> Sending encrypted inputs")
         await self._websocket.send(input_ciphertext)
-        result = await self._websocket.recv()
+        response = await self._websocket.recv()
         logger.debug("< Received function results")
-        result = _parse_websocket_result(result)
+        result = _parse_wss_response(response)
 
         if msgpack_serialize:
             result = serde.deserialize(result, object_hook=decoder_hook)
@@ -142,7 +138,9 @@ class Cape:
 
 # TODO What should be the length?
 def _generate_nonce(length=8):
-    return "".join([str(random.randint(0, 9)) for i in range(length)])
+    nonce = "".join([str(random.randint(0, 9)) for i in range(length)])
+    logger.debug(f"* Generated nonce: {nonce}")
+    return nonce
 
 
 def _create_connection_request(token, nonce):
@@ -150,22 +148,23 @@ def _create_connection_request(token, nonce):
     return json.dumps(request)
 
 
-def _parse_attestation_response(result):
-    result = json.loads(result)
-    if "error" in result:
-        raise Exception(result["error"])
-
-    return result["message"]
-
-
-def _parse_websocket_result(result):
-    result = json.loads(result)
-    if "error" in result:
-        raise Exception(result["error"])
-
-    msg = result["message"]
-    data = base64.b64decode(msg["message"])
-    return data
+def _parse_wss_response(response):
+    response = json.loads(response)
+    if "error" in response:
+        raise Exception(response["error"])
+    response_msg = _handle_expected_field(
+        response,
+        "message",
+        fallback_err="Missing 'message' field in websocket response.",
+    )
+    inner_msg = _handle_expected_field(
+        response_msg,
+        "message",
+        fallback_err=(
+            "Malformed websocket response contents: missing inner " "'message' field."
+        ),
+    )
+    return base64.b64decode(inner_msg)
 
 
 def _handle_default_auth(auth_path: pathlib.Path):
@@ -176,20 +175,19 @@ def _handle_default_auth(auth_path: pathlib.Path):
         )
     with open(auth_path, "r") as auth_file:
         auth_dict = json.load(auth_file)
-    access_token = auth_dict.get("access_token", None)
-    if access_token is None:
-        raise ValueError(
-            "Malformed auth file found: missing 'access_token' JSON field."
-        )
+    access_token = _handle_expected_field(
+        auth_dict,
+        "access_token",
+        fallback_err="Malformed auth file found: missing 'access_token' JSON field.",
+    )
     return access_token
 
 
-def download_root_cert():
-    url = "https://aws-nitro-enclaves.amazonaws.com/AWS_NitroEnclaves_Root-G1.zip"
-    r = requests.get(url)
-
-    f = zipfile.ZipFile(io.BytesIO(r.content))
-    with f.open("root.pem") as p:
-        root_cert = p.read()
-
-    return root_cert
+def _handle_expected_field(dictionary, field, *, fallback_err=None):
+    v = dictionary.get(field, None)
+    if v is None:
+        if fallback_err is not None:
+            logger.error(fallback_err)
+            raise RuntimeError(fallback_err)
+        raise RuntimeError(f"Dictionary {dictionary} missing key {field}.")
+    return v

--- a/pycape/cape.py
+++ b/pycape/cape.py
@@ -20,13 +20,14 @@ from pycape import serde
 _CAPE_CONFIG_PATH = pathlib.Path.home() / ".config" / "cape"
 _DISABLE_SSL = os.environ.get("CAPEDEV_DISABLE_SSL", False)
 
-
 logging.basicConfig(format="%(message)s")
 logger = logging.getLogger("pycape")
 
 
 class Cape:
-    def __init__(self, url="wss://cape.run", access_token=None, verbose=False):
+    def __init__(
+        self, url="wss://hackathon.capeprivacy.com", access_token=None, verbose=False
+    ):
         self._url = url
         if access_token is None:
             cape_auth_path = _CAPE_CONFIG_PATH / "auth"

--- a/pycape/enclave_encrypt.py
+++ b/pycape/enclave_encrypt.py
@@ -1,6 +1,11 @@
+import logging
+
 import hpke_spec
+
+logger = logging.getLogger("pycape")
 
 
 def encrypt(public_key, input_bytes):
+    logger.debug("* Encrypting inputs with Hybrid Public Key Encryption (HPKE)")
     ciphertext = hpke_spec.hpke_seal(public_key, input_bytes)
     return ciphertext


### PR DESCRIPTION
Changes default wss URL from `cape.run` to `hackathon.capeprivacy.com`