### PR TITLE
Update examples with function hash

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,11 +38,11 @@ Before running a function, you need to first get an access token (`<AUTH_TOKEN>`
 ### `run`
 
 Run is used to invoke a function once with a single input.
-We now return function hash to the user during deploy. If function hash is specified to None, then
+Cape returns a function hash to the user during deploy. If function hash is specified to None, then
 verification of function hash will not occur. It is encouraged to always provide the desired function
 hash for security. 
 
-Example [run.py](https://github.com/capeprivacy/pycape/tree/main/examples/run.py):
+Example [run_echo.py](https://github.com/capeprivacy/pycape/blob/main/examples/run_echo.py):
 
 ```py
 from pycape import Cape, FunctionRef
@@ -55,7 +55,7 @@ client.run(function_ref=FunctionRef(function_id='<FUNCTION_ID>', function_hash='
 
 Invoke is used to run a function repeatedly with multiple inputs. It gives you more control over the lifecycle of the function invocation.
 
-Example [invoke.py](https://github.com/capeprivacy/pycape/blob/main/examples/invoke.py):
+Example [invoke_echo.py](https://github.com/capeprivacy/pycape/blob/main/examples/invoke_echo.py):
 
 ```py
 from pycape import Cape

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,6 +1,6 @@
 # Examples
 
-Before running a function, you need to first get an access token (`<AUTH_TOKEN>`) with the [Cape CLI](https://github.com/capeprivacy/cli) by running `cape login`. Once logged into Cape, you can find the access token in your `~/.config` directory as follows: `cat ~/.config/cape/auth`. Then you'll obtain a function id ('<FUNCTION_ID>') once you have deployed your function with `cape deploy`.
+Before running a function, you need to first get an access token (`<AUTH_TOKEN>`) with the [Cape CLI](https://github.com/capeprivacy/cli) by running `cape login`. Once logged into Cape, you can find the access token in your `~/.config` directory as follows: `cat ~/.config/cape/auth`. Then you'll obtain a function id ('<FUNCTION_ID>') and a function hash (`<FUNCTION_HASH>`) once you have deployed your function with `cape deploy`. If a function hash is not specified then the verification of the function hash will not occur. It is encouraged to always provide the desired function hash for security. 
 
 ## Echo: running functions on raw bytes
 
@@ -15,7 +15,8 @@ After deploying the function, to run a function once, you can run the following 
 ```
 export CAPE_TOKEN=<AUTH_TOKEN>
 export CAPE_HOST=<WSS_URL>
-export CAPE_FUNCTION=<FUNCTION_ID returned from cape deploy>
+export CAPE_FUNCTION_ID=<FUNCTION_ID returned from cape deploy>
+export CAPE_FUNCTION_HASH=<FUNCTION_HASH returned from cape deploy>
 python run_echo.py
 ```
 
@@ -23,7 +24,8 @@ To run a function repeatedly, you can run the following example:
 ```
 export CAPE_TOKEN=<AUTH_TOKEN>
 export CAPE_HOST=<WSS_URL>
-export CAPE_FUNCTION=<FUNCTION_ID returned from cape deploy>
+export CAPE_FUNCTION_ID=<FUNCTION_ID returned from cape deploy>
+export CAPE_FUNCTION_HASH=<FUNCTION_HASH returned from cape deploy>
 python invoke_echo.py
 ```
 

--- a/examples/invoke_echo.py
+++ b/examples/invoke_echo.py
@@ -1,15 +1,21 @@
 import os
 
-from pycape.cape import Cape
+from pycape import Cape
+from pycape import FunctionRef
 
 if __name__ == "__main__":
     token = os.environ.get("CAPE_TOKEN", None)
-    url = os.environ.get("CAPE_HOST", "wss://cape.run")
+    url = os.environ.get("CAPE_HOST", "wss://hackathon.capeprivacy.com")
+    function_id = os.environ.get("CAPE_FUNCTION_ID", "VNgMtygWv8wCwwjbbQ2kH6")
+    function_hash = os.environ.get("CAPE_FUNCTION_HASH", None)
+
+    if function_hash is None:
+        function_ref = function_id
+    else:
+        function_ref = FunctionRef(function_id, function_hash)
+
     cape = Cape(url=url, access_token=token)
-    function_id = os.environ.get(
-        "CAPE_FUNCTION", "e4c2a674-9c7f-42d3-8ade-63791c16c3c7"
-    )
-    cape.connect(function_id)
+    cape.connect(function_ref)
 
     result = cape.invoke("Hello Cape".encode())
     print(f"The result is: {result.decode()}")

--- a/examples/run_echo.py
+++ b/examples/run_echo.py
@@ -1,16 +1,21 @@
 import os
 
 from pycape import Cape
+from pycape import FunctionRef
 
 if __name__ == "__main__":
     token = os.environ.get("CAPE_TOKEN", None)
     url = os.environ.get("CAPE_HOST", "wss://hackathon.capeprivacy.com")
-    function_id = os.environ.get(
-        "CAPE_FUNCTION", "e4c2a674-9c7f-42d3-8ade-63791c16c3c7"
-    )
+    function_id = os.environ.get("CAPE_FUNCTION_ID", "VNgMtygWv8wCwwjbbQ2kH6")
+    function_hash = os.environ.get("CAPE_FUNCTION_HASH", None)
+
+    if function_hash is None:
+        function_ref = function_id
+    else:
+        function_ref = FunctionRef(function_id, function_hash)
 
     cape = Cape(url=url, access_token=token)
     input = "Welcome to Cape".encode()
-    result = cape.run(function_id, input)
+    result = cape.run(function_ref, input)
 
     print(f"The result is: {result.decode()}")

--- a/examples/run_mean.py
+++ b/examples/run_mean.py
@@ -1,17 +1,24 @@
 import os
 
 from pycape import Cape
+from pycape import FunctionRef
 
 if __name__ == "__main__":
     token = os.environ.get("CAPE_TOKEN", None)
     url = os.environ.get("CAPE_HOST", "wss://hackathon.capeprivacy.com")
     function_id = os.environ.get(
-        "CAPE_FUNCTION", "e4c2a674-9c7f-42d3-8ade-63791c16c3c7"
+        "CAPE_FUNCTION_ID", "e4c2a674-9c7f-42d3-8ade-63791c16c3c7"
     )
+    function_hash = os.environ.get("CAPE_FUNCTION_HASH", None)
+
+    if function_hash is None:
+        function_ref = function_id
+    else:
+        function_ref = FunctionRef(function_id, function_hash)
 
     cape = Cape(url=url, access_token=token)
 
     x = [1, 2, 3, 4]
-    result = cape.run(function_id, x, use_serdio=True)
+    result = cape.run(function_ref, x, use_serdio=True)
 
     print(f"The mean of x is: {result}")

--- a/pycape/cape.py
+++ b/pycape/cape.py
@@ -222,10 +222,11 @@ def _handle_expected_field(dictionary, field, *, fallback_err=None):
 
 def _convert_to_function_ref(function_ref):
     if isinstance(function_ref, str):
-        function_ref = FunctionRef(function_ref)
+        return FunctionRef(function_ref)
     elif isinstance(function_ref, FunctionRef):
         return function_ref
-    raise TypeError(
-        "`function_ref` arg must be a string function ID, "
-        f"or a FunctionRef object, found {type(function_ref)}"
-    )
+    else:
+        raise TypeError(
+            "`function_ref` arg must be a string function ID, "
+            f"or a FunctionRef object, found {type(function_ref)}"
+        )


### PR DESCRIPTION
CAPE-788

This PR add the following:
- Fixes a bug in `_convert_to_function_ref`. Because of branching, it was always raising error and returning None when `function_ref` was a string
- Add function hash to examples
- Fix examples' link in the main README

Thanks