### PR TITLE
Fix encoding msgpack for multiple none python native type

### DIFF
--- a/serdio/serdio/_test_utils.py
+++ b/serdio/serdio/_test_utils.py
@@ -1,0 +1,39 @@
+import dataclasses
+
+
+def identity(x):
+    return x
+
+
+def multiple_identity(x, y, z=1):
+    return x, y, z
+
+
+@dataclasses.dataclass
+class MyCoolResult:
+    cool_result: float
+
+
+@dataclasses.dataclass
+class MyCoolClass:
+    cool_float: float
+    cool_int: int
+
+    def mul(self):
+        return MyCoolResult(self.cool_int * self.cool_float)
+
+
+def my_cool_encoder(x):
+    if dataclasses.is_dataclass(x):
+        return {"__type__": x.__class__.__name__, "fields": dataclasses.asdict(x)}
+    return x
+
+
+def my_cool_decoder(obj):
+    if "__type__" in obj:
+        obj_type = obj["__type__"]
+        if obj_type == "MyCoolClass":
+            return MyCoolClass(**obj["fields"])
+        elif obj_type == "MyCoolResult":
+            return MyCoolResult(**obj["fields"])
+    return obj

--- a/serdio/serdio/io_lifter_test.py
+++ b/serdio/serdio/io_lifter_test.py
@@ -132,7 +132,9 @@ class TestIoLifter(parameterized.TestCase):
 
     def test_multiple_not_native_python_types(self):
         @lifting.lift_io(encoder_hook=my_cool_encoder, decoder_hook=my_cool_decoder)
-        def my_cool_function(x: MyCoolClass, y: MyCoolClass, z: MyCoolClass) -> MyCoolResult:
+        def my_cool_function(
+            x: MyCoolClass, y: MyCoolClass, z: MyCoolClass
+        ) -> MyCoolResult:
             return x.mul(), y.mul(), z.mul()
 
         # # runs as normal
@@ -142,7 +144,9 @@ class TestIoLifter(parameterized.TestCase):
         assert res == expected_cool_result
 
         # cape handler runs on bytes
-        cool_input_pack = func_utils.pack_function_args_kwargs((cool_input, cool_input), {"z": cool_input})
+        cool_input_pack = func_utils.pack_function_args_kwargs(
+            (cool_input, cool_input), {"z": cool_input}
+        )
         cool_input_ser = serde.serialize(cool_input_pack, encoder=my_cool_encoder)
         cape_handler = my_cool_function.as_cape_handler()
         cool_result_ser = cape_handler(cool_input_ser)

--- a/serdio/serdio/serde.py
+++ b/serdio/serdio/serde.py
@@ -53,7 +53,7 @@ def serialize(x, encoder=None):
                 f"`encoder` arg needs to be callable, found type {type(encoder)}"
             )
         encode_hook = lambda x: encoder(_default_encoder(x))  # noqa: E731
-    return msgpack.packb(x, default=encode_hook, strict_types=True)
+    return msgpack.packb(x, default=encode_hook, strict_types=False)
 
 
 def deserialize(x_bytes, decoder=None):

--- a/serdio/serdio/serde.py
+++ b/serdio/serdio/serde.py
@@ -52,8 +52,8 @@ def serialize(x, encoder=None):
             raise TypeError(
                 f"`encoder` arg needs to be callable, found type {type(encoder)}"
             )
-        encode_hook = lambda x: encoder(_default_encoder(x))  # noqa: E731
-    return msgpack.packb(x, default=encode_hook, strict_types=False)
+        encode_hook = lambda x: _default_encoder(encoder(x))  # noqa: E731
+    return msgpack.packb(x, default=encode_hook, strict_types=True)
 
 
 def deserialize(x_bytes, decoder=None):

--- a/serdio/serdio/serde.py
+++ b/serdio/serdio/serde.py
@@ -14,33 +14,45 @@ class _MsgpackExtType(enum.IntEnum):
     native_frozenset = 4
 
 
-def _default_encoder(x):
+def _default_encoder(x, custom_encoder=None):
+    if custom_encoder is None:
+        custom_encoder = lambda x: x  # noqa: E731
     if isinstance(x, complex):
         return msgpack.ExtType(
-            _MsgpackExtType.native_complex, msgpack.packb((x.real, x.imag))
+            _MsgpackExtType.native_complex,
+            msgpack.packb((x.real, x.imag), default=custom_encoder),
         )
     elif isinstance(x, tuple):
-        return msgpack.ExtType(_MsgpackExtType.native_tuple, msgpack.packb(list(x)))
+        return msgpack.ExtType(
+            _MsgpackExtType.native_tuple, msgpack.packb(list(x), default=custom_encoder)
+        )
     elif isinstance(x, set):
-        return msgpack.ExtType(_MsgpackExtType.native_set, msgpack.packb(list(x)))
+        return msgpack.ExtType(
+            _MsgpackExtType.native_set, msgpack.packb(list(x), default=custom_encoder)
+        )
     elif isinstance(x, frozenset):
-        return msgpack.ExtType(_MsgpackExtType.native_frozenset, msgpack.packb(list(x)))
+        return msgpack.ExtType(
+            _MsgpackExtType.native_frozenset,
+            msgpack.packb(list(x), default=custom_encoder),
+        )
     return x
 
 
-def _msgpack_ext_unpack(code, data):
+def _msgpack_ext_unpack(code, data, custom_decoder=None):
     """Messagepack decoders for custom types."""
+    if custom_decoder is None:
+        custom_decoder = lambda x: x  # noqa: E731
     if code == _MsgpackExtType.native_complex:
-        complex_tuple = msgpack.unpackb(data)
+        complex_tuple = msgpack.unpackb(data, object_hook=custom_decoder)
         return complex(complex_tuple[0], complex_tuple[1])
     elif code == _MsgpackExtType.native_tuple:
-        tuple_list = msgpack.unpackb(data)
+        tuple_list = msgpack.unpackb(data, object_hook=custom_decoder)
         return tuple(tuple_list)
     elif code == _MsgpackExtType.native_set:
-        set_list = msgpack.unpackb(data)
+        set_list = msgpack.unpackb(data, object_hook=custom_decoder)
         return set(set_list)
     elif code == _MsgpackExtType.native_frozenset:
-        frozenset_list = msgpack.unpackb(data)
+        frozenset_list = msgpack.unpackb(data, object_hook=custom_decoder)
         return frozenset(frozenset_list)
     return msgpack.ExtType(code, data)
 
@@ -52,17 +64,23 @@ def serialize(x, encoder=None):
             raise TypeError(
                 f"`encoder` arg needs to be callable, found type {type(encoder)}"
             )
-        encode_hook = lambda x: _default_encoder(encoder(x))  # noqa: E731
+        encode_hook = lambda x: _default_encoder(  # noqa: E731
+            encoder(x), custom_encoder=encoder
+        )
     return msgpack.packb(x, default=encode_hook, strict_types=True)
 
 
 def deserialize(x_bytes, decoder=None):
+    ext_hook = _msgpack_ext_unpack
     if decoder is not None:
         if not callable(decoder):
             raise TypeError(
                 f"`decoder` needs to be a callable, found type {type(decoder)}"
             )
-    return msgpack.unpackb(x_bytes, ext_hook=_msgpack_ext_unpack, object_hook=decoder)
+        ext_hook = lambda c, d: _msgpack_ext_unpack(  # noqa: E731
+            c, d, custom_decoder=decoder
+        )
+    return msgpack.unpackb(x_bytes, ext_hook=ext_hook, object_hook=decoder)
 
 
 @dataclasses.dataclass

--- a/serdio/serdio/serde_test.py
+++ b/serdio/serdio/serde_test.py
@@ -2,6 +2,7 @@ import msgpack
 from absl.testing import absltest
 from absl.testing import parameterized
 
+from serdio import _test_utils as ut
 from serdio import serde
 
 
@@ -23,9 +24,26 @@ class SerializeTest(parameterized.TestCase):
             bytearray([1]),
         ]
     )
-    def test_serialize(self, x):
+    def test_serde(self, x):
         x_bytes = serde.serialize(x)
         x_deser = serde.deserialize(x_bytes)
+        assert x == x_deser
+
+    @parameterized.parameters(
+        {"x": x}
+        for x in [
+            ut.MyCoolClass(2, 3.0),
+            ut.MyCoolResult(6.0),
+            (ut.MyCoolClass(2, 3.0), ut.MyCoolResult(6.0)),
+            {
+                "classes": (ut.MyCoolClass(2, 3.0), ut.MyCoolClass(4, 6.0)),
+                "results": (ut.MyCoolResult(6.0), ut.MyCoolResult(24.0)),
+            },
+        ]
+    )
+    def test_custom_types(self, x):
+        x_bytes = serde.serialize(x, ut.my_cool_encoder)
+        x_deser = serde.deserialize(x_bytes, ut.my_cool_decoder)
         assert x == x_deser
 
 


### PR DESCRIPTION
With `strict_types=False`, I was able to serialize a tuple of numpy arrays, without it couldn't deserialize.