### PR TITLE
Use newer hybrid-pke 1.0

### DIFF
--- a/pycape/enclave_encrypt.py
+++ b/pycape/enclave_encrypt.py
@@ -1,11 +1,14 @@
 import logging
 
-import hpke_spec
+import hybrid_pke
 
 logger = logging.getLogger("pycape")
 
 
 def encrypt(public_key, input_bytes):
     logger.debug("* Encrypting inputs with Hybrid Public Key Encryption (HPKE)")
-    ciphertext = hpke_spec.hpke_seal(public_key, input_bytes)
+    hpke = hybrid_pke.default()
+    info = b""
+    aad = b""
+    _, ciphertext = hpke.seal(public_key, info, aad, input_bytes)
     return ciphertext

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -1,5 +1,5 @@
 cbor2
-hpke_spec~=0.2.0
+hybrid_pke~=1.0
 file:./serdio
 websockets
 pyOpenSSL

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -30,7 +30,7 @@ cryptography==37.0.4
     #   pyopenssl
 ecdsa==0.18.0
     # via cose
-hpke-spec==0.2.0
+hybrid-pke==1.0.0
     # via -r requirements/base.in
 idna==3.3
     # via requests


### PR DESCRIPTION
switch from the `hpke-spec` pypi lib to the [`hybrid-pke` lib](https://github.com/capeprivacy/hybrid-pke), which is what we renamed it to. also this updates to use the 1.0.0 release for that library