### PR TITLE
Remove receive payload limit in websocket

### DIFF
--- a/pycape/cape.py
+++ b/pycape/cape.py
@@ -207,7 +207,7 @@ class Cape:
             ctx.verify_mode = ssl.CERT_NONE
 
         logger.debug(f"* Dialing {self._url}")
-        self._websocket = await websockets.connect(endpoint, ssl=ctx)
+        self._websocket = await websockets.connect(endpoint, ssl=ctx, max_size=None)
         logger.debug("* Websocket connection established")
 
         nonce = _generate_nonce()


### PR DESCRIPTION
[CAPE-840](https://capeprivacy.atlassian.net/browse/CAPE-840)

During the hackathon, I discovered we could receive a payload larger than 1MB. The send limit is controlled on the server side.