### PR TITLE
update examples readme

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -11,7 +11,7 @@ To automatically deploy and run an example function that performs `echo`, run:
 python3 deploy_run_echo.py
 ```
 
-Alternatively, you can `cape login` and `cape deploy` with Cape's CLI and set the following environment variables as follows. 
+Alternatively, you can use the Cape CLI directly via `cape login` and `cape deploy` as follows. 
 Once you have logged into Cape with `cape login` deploy the echo functions by running:
 ```
 cape deploy echo/

--- a/examples/README.md
+++ b/examples/README.md
@@ -6,14 +6,19 @@ Before running a function, you need to first get an access token (`<AUTH_TOKEN>`
 
 By default, Cape functions expect bytes as input and return bytes as output. For this first example, we run an echo function which expects bytes and return bytes as output.
 
-Once you have logged into Cape with `cape login` deploy the echo functions as follow:
+To automatically deploy and run an example function that performs `echo`, run:
+```
+python3 deploy_run_echo.py
+```
+
+Alternatively, you can `cape login` and `cape deploy` with Cape's CLI and set the following environment variables as follows. 
+Once you have logged into Cape with `cape login` deploy the echo functions by running:
 ```
 cape deploy echo/
 ```
 
 After deploying the function, to run a function once, you can run the following example:
 ```
-export CAPE_TOKEN=<AUTH_TOKEN>
 export CAPE_HOST=<WSS_URL>
 export CAPE_FUNCTION_ID=<FUNCTION_ID returned from cape deploy>
 export CAPE_FUNCTION_HASH=<FUNCTION_HASH returned from cape deploy>
@@ -22,7 +27,6 @@ python run_echo.py
 
 To run a function repeatedly, you can run the following example:
 ```
-export CAPE_TOKEN=<AUTH_TOKEN>
 export CAPE_HOST=<WSS_URL>
 export CAPE_FUNCTION_ID=<FUNCTION_ID returned from cape deploy>
 export CAPE_FUNCTION_HASH=<FUNCTION_HASH returned from cape deploy>


### PR DESCRIPTION
Updates the readme for examples to reflect that: (1) CAPE_TOKEN does not need to be set as an environment variable, (2) that deploy_run_echo.py is available for a user to run without setting any environment variables.