### PR TITLE
replace encrypt fn w/ EncryptionContext and use it in Cape client

### DIFF
--- a/pycape/enclave_encrypt.py
+++ b/pycape/enclave_encrypt.py
@@ -5,10 +5,12 @@ import hybrid_pke
 logger = logging.getLogger("pycape")
 
 
-def encrypt(public_key, input_bytes):
-    logger.debug("* Encrypting inputs with Hybrid Public Key Encryption (HPKE)")
-    hpke = hybrid_pke.default()
-    info = b""
-    aad = b""
-    encap, ciphertext = hpke.seal(public_key, info, aad, input_bytes)
-    return encap + ciphertext
+class EncryptionContext:
+    def __init__(self, public_key: bytes):
+        self._hpke = hybrid_pke.default()
+        self._encap, self._ctx = self._hpke.setup_sender(public_key, info=b"")
+
+    def seal(self, plain_txt: bytes) -> bytes:
+        aad = b""
+        cipher_txt = self._ctx.seal(aad, plain_txt)
+        return self._encap + cipher_txt

--- a/pycape/enclave_encrypt_test.py
+++ b/pycape/enclave_encrypt_test.py
@@ -7,7 +7,7 @@ from pycape.attestation import parse_attestation
 from pycape.attestation_test import create_attestation_doc
 from pycape.attestation_test import create_certs
 from pycape.attestation_test import create_cose_1_sign_msg
-from pycape.enclave_encrypt import encrypt
+from pycape import enclave_encrypt
 
 
 class TestEnclaveEncryption:
@@ -27,4 +27,6 @@ class TestEnclaveEncryption:
         public_key, _ = parse_attestation(
             attestation, root_cert.public_bytes(Encoding.PEM)
         )
-        _ = encrypt(public_key, plaintext)
+        ctx = enclave_encrypt.EncryptionContext(public_key)
+        sealed = ctx.seal(plaintext)
+        assert len(sealed) > 32  # encapsulated key is 32 bytes for default hpke config

--- a/pycape/enclave_encrypt_test.py
+++ b/pycape/enclave_encrypt_test.py
@@ -1,13 +1,14 @@
+import hybrid_pke
 from cose.keys.curves import P384
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives.asymmetric import ec
 from cryptography.hazmat.primitives.serialization import Encoding
 
+from pycape import enclave_encrypt
 from pycape.attestation import parse_attestation
 from pycape.attestation_test import create_attestation_doc
 from pycape.attestation_test import create_certs
 from pycape.attestation_test import create_cose_1_sign_msg
-from pycape import enclave_encrypt
 
 
 class TestEnclaveEncryption:
@@ -30,3 +31,29 @@ class TestEnclaveEncryption:
         ctx = enclave_encrypt.EncryptionContext(public_key)
         sealed = ctx.seal(plaintext)
         assert len(sealed) > 32  # encapsulated key is 32 bytes for default hpke config
+
+    def test_multiroundtrip(self):
+        plaintext = b"private_data"
+        hpke = hybrid_pke.default()
+
+        crv = P384
+        root_private_key = ec.generate_private_key(
+            crv.curve_obj, backend=default_backend()
+        )
+        private_key = ec.generate_private_key(crv.curve_obj, backend=default_backend())
+
+        root_cert, cert = create_certs(root_private_key, private_key)
+        doc_bytes = create_attestation_doc(root_cert, cert)
+        attestation = create_cose_1_sign_msg(doc_bytes, private_key)
+
+        public_key, _ = parse_attestation(
+            attestation, root_cert.public_bytes(Encoding.PEM)
+        )
+        ctx = enclave_encrypt.EncryptionContext(public_key)
+
+        for _ in range(3):
+            sealed = ctx.seal(plaintext)
+            encap = sealed[:32]
+            cipher = sealed[32:]
+            result = hpke.open(encap, cipher_txt=cipher, info=b"", aad=b"")
+            assert result == b"private_data"


### PR DESCRIPTION
CAPE-899

use the context api instead of the single-shot api for HPKE encryption. this prevents us from making redundant calls to `hpke.setup_sender` on each call to `Cape.invoke`