### PR TITLE
Generate API docs w/ Sphinx

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,9 @@
+# ignore some generated sphinx files 
+docs/source/*.rst
+docs/source/*.md
+!docs/source/index.rst
+!docs/source/walkthrough.md
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/Makefile
+++ b/Makefile
@@ -66,3 +66,32 @@ bump-minor: bump-prep
 bump-major: bump-prep
 	bumpver update --major --tag=final
 	bumpver update --patch --tag=rc --no-tag-commit
+
+# Docs
+.PHONY: install-docs
+install-docs:
+	pip install -U sphinx myst-parser sphinx-book-theme
+
+.PHONY: docs-clean
+docs-clean:
+	find docs/source -name "*.rst" ! -name "index.rst" -exec rm {} \+
+	find docs/source -name "*.md" ! -name "walkthrough.md" -exec rm {} \+
+	cd docs && \
+	make clean && \
+	cd ..
+
+.PHONY: docs-prep
+docs-prep: install-docs install-release docs-clean
+	cp README.md docs/source/pycape-readme.md && \
+	cp serdio/README.md docs/source/serdio-readme.md && \
+	cd docs && \
+	sphinx-apidoc -f -o source ../pycape "../pycape/*_test*" --separate && \
+	sphinx-apidoc -f -o source ../serdio "../serdio/*_test*" --separate && \
+	rm source/modules.rst && \
+	cd ..
+
+.PHONY: docs
+docs: docs-prep
+	cd docs && \
+	make html && \
+	cd ..

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Pycape
+# PyCape
 
 The Cape SDK for Python is a library that provides a simple way to interact with the Cape Privacy API.
 
@@ -51,7 +51,7 @@ hash for security.
 
 Example [run_echo.py](https://github.com/capeprivacy/pycape/blob/main/examples/run_echo.py):
 
-```py
+```python
 from pycape import Cape
 from pycape import FunctionRef
 
@@ -61,7 +61,7 @@ function_hash = "cbca8c9f7ac41138935018c3f45cd16d1abfbe15a37b1fc09a11dfbc3d44b44
 f = FunctionRef(function_id, function_hash)
 result = client.run(f, b"Hello!")
 print(result.decode())
->> hello!
+# Hello!
 ```
 
 ### `invoke`
@@ -70,7 +70,7 @@ Invoke is used to run a function repeatedly with multiple inputs. It gives you m
 
 Example [invoke_echo.py](https://github.com/capeprivacy/pycape/blob/main/examples/invoke_echo.py):
 
-```py
+```python
 from pycape import Cape
 from pycape import FunctionRef
 
@@ -81,13 +81,13 @@ f = FunctionRef(function_id, function_hash)
 client.connect(f)
 result = client.invoke(b"Hello Alice!")
 print(result.decode())
->> Hello Alice!
+# Hello Alice!
 result = client.invoke(b"Hello Bob!")
 print(result.decode())
->> Hello Bob!
+# Hello Bob!
 result = client.invoke(b"Hello Carole!")
 print(result.decode())
->> Hello Carole!
+# Hello Carole!
 ```
 
 <p align="right">(<a href="#top">back to top</a>)</p>

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = source
+BUILDDIR      = _build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -1,0 +1,35 @@
+@ECHO OFF
+
+pushd %~dp0
+
+REM Command file for Sphinx documentation
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set SOURCEDIR=source
+set BUILDDIR=_build
+
+%SPHINXBUILD% >NUL 2>NUL
+if errorlevel 9009 (
+	echo.
+	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+	echo.installed, then set the SPHINXBUILD environment variable to point
+	echo.to the full path of the 'sphinx-build' executable. Alternatively you
+	echo.may add the Sphinx directory to PATH.
+	echo.
+	echo.If you don't have Sphinx installed, grab it from
+	echo.https://www.sphinx-doc.org/
+	exit /b 1
+)
+
+if "%1" == "" goto help
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+goto end
+
+:help
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+
+:end
+popd

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,0 +1,56 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# This file only contains a selection of the most common options. For a full
+# list see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Path setup --------------------------------------------------------------
+
+# If extensions (or modules to document with autodoc) are in another directory,
+# add these directories to sys.path here. If the directory is relative to the
+# documentation root, use os.path.abspath to make it absolute, like shown here.
+#
+import os
+import sys
+sys.path.insert(0, os.path.abspath('../../'))
+
+
+# -- Project information -----------------------------------------------------
+
+project = 'PyCape'
+copyright = '2022, Cape Privacy'
+author = 'Cape Privacy'
+
+
+# -- General configuration ---------------------------------------------------
+
+# Add any Sphinx extension module names here, as strings. They can be
+# extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
+# ones.
+extensions = [
+    'sphinx.ext.napoleon',
+    'myst_parser',
+]
+
+napoleon_include_init_with_doc = True
+
+# Add any paths that contain templates here, relative to this directory.
+templates_path = ['../_templates']
+
+# List of patterns, relative to source directory, that match files and
+# directories to ignore when looking for source files.
+# This pattern also affects html_static_path and html_extra_path.
+exclude_patterns = ['../_build', 'Thumbs.db', '.DS_Store']
+
+
+# -- Options for HTML output -------------------------------------------------
+
+# The theme to use for HTML and HTML Help pages.  See the documentation for
+# a list of builtin themes.
+#
+html_theme = 'sphinx_book_theme'
+
+# Add any paths that contain custom static files (such as style sheets) here,
+# relative to this directory. They are copied after the builtin static files,
+# so a file named "default.css" will overwrite the builtin "default.css".
+html_static_path = ['../_static']

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -12,14 +12,15 @@
 #
 import os
 import sys
-sys.path.insert(0, os.path.abspath('../../'))
+
+sys.path.insert(0, os.path.abspath("../../"))
 
 
 # -- Project information -----------------------------------------------------
 
-project = 'PyCape'
-copyright = '2022, Cape Privacy'
-author = 'Cape Privacy'
+project = "PyCape"
+copyright = "2022, Cape Privacy"
+author = "Cape Privacy"
 
 
 # -- General configuration ---------------------------------------------------
@@ -28,19 +29,19 @@ author = 'Cape Privacy'
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
-    'sphinx.ext.napoleon',
-    'myst_parser',
+    "sphinx.ext.napoleon",
+    "myst_parser",
 ]
 
 napoleon_include_init_with_doc = True
 
 # Add any paths that contain templates here, relative to this directory.
-templates_path = ['../_templates']
+templates_path = ["../_templates"]
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
-exclude_patterns = ['../_build', 'Thumbs.db', '.DS_Store']
+exclude_patterns = ["../_build", "Thumbs.db", ".DS_Store"]
 
 
 # -- Options for HTML output -------------------------------------------------
@@ -48,9 +49,9 @@ exclude_patterns = ['../_build', 'Thumbs.db', '.DS_Store']
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = 'sphinx_book_theme'
+html_theme = "sphinx_book_theme"
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['../_static']
+html_static_path = ["../_static"]

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,0 +1,30 @@
+.. PyCape documentation master file, created by
+   sphinx-quickstart on Mon Aug 29 13:00:06 2022.
+   You can adapt this file completely to your liking, but it should at least
+   contain the root `toctree` directive.
+
+Welcome to PyCape's documentation!
+==================================
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Overview Docs
+
+   pycape-readme
+   walkthrough
+   serdio-readme
+
+.. toctree::
+   :maxdepth: 2
+   :caption: API Reference
+
+   pycape
+   serdio
+
+
+Indices and tables
+==================
+
+* :ref:`genindex`
+* :ref:`modindex`
+* :ref:`search`

--- a/docs/source/walkthrough.md
+++ b/docs/source/walkthrough.md
@@ -1,0 +1,150 @@
+Walkthrough
+=================
+
+<details>
+  <summary>Table of Contents</summary>
+  <ol>
+    <li><a href="#introduction">Introduction</a></li>
+    <li><a href="#a-simple-example">A Simple Example</a></li>
+    <li><a href="#mean-v2-running-functions-on-python-types-with-serdio">Mean v2</a></li>
+    <li><a href="#invoking-a-cape-function-multiple-times">Invoking a Cape function multiple times</a></li>
+  </ol>
+</details>
+
+## Introduction 
+The PyCape SDK helps users write their Cape functions in Python, and allows users to run functions which have already been deployed to Cape. Users call these functions from Python using either Cape.run or Cape.invoke. The PyCape SDK also provides some extra utilities for Python users to prepare their functions for the enclave.
+
+Prior to following this walkthrough, we encourage the reader to set up their local environment by following the [Quick Start guide](https://docs.capeprivacy.com/getting-started).
+
+In this guide, we will walk through several examples of writing a Cape function and invoking it from Python.
+
+## A Simple Example
+
+Let’s start by writing a simple function.  In this example, we'll take the average, or mean, of a list of numbers. Cape expects a `cape_handler` function that takes a single parameter of bytes as input. We refer to this as a “Cape function”.
+
+Here’s a Cape function that computes the mean of a list of numbers:
+```python
+import json
+import statistics
+ 
+def cape_handler(x_bytes):
+   x = json.loads(x_bytes.decode())
+   x_mean = statistics.mean(x)
+   return json.dumps(x_mean).encode()
+```
+
+### Deploying our first function
+To deploy this function, we can follow two steps.
+
+First, save the code into an `app.py` file in a folder called `mean`, similar to the [“Writing Functions” guide](https://docs.capeprivacy.com/functions/how-to). The result should look like [this example](https://github.com/capeprivacy/pycape/tree/main/examples/mean). 
+
+Then deploy this folder by calling `cape deploy mean`, per the [“Deploying Functions” guide](https://docs.capeprivacy.com/functions/deploying).
+
+### Running our first function
+
+Once we’ve deployed the Cape function successfully, we’ll have a function ID and hash that we can use to reference it elsewhere. We'll use this reference to call the function from PyCape as follows:
+
+```python
+cape = Cape()
+function_id = "4akLQwrqydyXYdyqn9qpSK"
+function_hash = "8d3559c4d22df470be639aedbbb32c0857d3aca45c78e98be24c8a31fe051f75"
+function_ref = FunctionRef(function_id, function_hash)
+x_bytes = json.dumps([1, 2, 3, 4]).encode()
+result_bytes = cape.run(function_ref, x_bytes)
+print("Mean of x is:", json.loads(result_bytes.decode()))
+# Mean of x is: 2.5
+```
+
+Congrats! We've called our first Cape function from PyCape.
+
+## Mean v2: Running functions on Python types with Serdio
+
+The previous example shows how to run a single-parameter function mapping bytes to bytes. However, handling serialization and deserialization of arbitrary inputs for every Cape function can lead to a lot of boilerplate. We can use Serdio to automate this for Cape functions with arbitrary signatures.
+
+**Serdio**, or **SER**ialization and **D**eserialization of (function) **I**nputs and **O**utputs, is a small library that simplifies the Cape function development process. Serdio implements automatic serialization and deserialization of native Python types with [MessagePack](https://msgpack.org/index.html), with additional support for custom types via user-supplied helpers.
+
+To use Serdio, we decorate our cape handler function with `@serdio.lift_io` and set `use_serdio=True` when we call `Cape.run` or `Cape.invoke`. See [examples/mean/app.py](https://github.com/capeprivacy/pycape/blob/main/examples/mean/app.py) for instructions on decorating.
+
+Let’s rewrite the previous averaging example in `app.py` to use Serdio: 
+
+```python
+import statistics
+import serdio
+ 
+@serdio.lift_io(as_handler=True)
+def cape_handler(x):
+   return statistics.mean(x)
+```
+ 
+In our first example, the code includes `json.loads` and `json.dumps` to convert from Python types to bytes. In the second example where we’ve added Serdio, we no longer need this extra step, as Serdio handles it for us automatically.
+
+However, we’ve introduced a new problem. Serdio is not part of the Python standard library, so the Cape enclave won’t know how to import it. We’ll need to add Serdio as a dependency to execute this Cape function in the enclave.
+
+### Adding Serdio as a dependency
+
+We can add the Serdio dependency similarly to how we would [add any other third-party dependency](https://docs.capeprivacy.com/reference/functions#adding-3rd-party-dependencies). First, we add a `requirements.txt` file that specifies the version of Serdio we want to use. In this case, it should be equivalent to the version of PyCape we're using:
+
+```
+serdio~=1.0.0
+```
+
+Then, we install this into the folder that contains our application code in `app.py`. In the previous example, this was the `mean` folder which we'll use again.
+```sh
+pip install serdio --target mean/
+```
+
+```{important}
+For more complicated Python dependencies that include C extension modules, this step will download and/or compile platform- and architecture-specific binaries. Therefore, running the installation step inside a Docker container like `python:3.9-slim-bullseye` is heavily recommended by the [third-party dependency guide](https://docs.capeprivacy.com/reference/functions#adding-3rd-party-dependencies).
+```
+
+Finally, re-deploy this code with `cape deploy mean`, and make note of the function ID and hash.
+
+### Running Mean v2 with PyCape
+
+After re-deploying this code, we can call it from PyCape like we did before.
+```python
+cape = Cape(url=url)
+function_id = "iHWCTH2hWZ9tUAhAnQpwWL"
+function_hash = "8f0cf0cc7d4c6bdd6459d0be9cb090668f80f6a1313d3f4cfb97efb8ba80d6cb"
+function_ref = FunctionRef(function_id, function_hash)
+x = [1, 2, 3, 4]
+result = cape.run(function_ref, x, use_serdio=True)
+print(f"The mean of x is: {result}")
+# Mean of x is: 2.5
+```
+
+## Invoking a Cape function multiple times
+If we want to invoke the same Cape function more than once in a Python application, we can take more explicit control PyCape's connection to the function enclave via a three-step process.
+1. Open the connection with `Cape.connect`
+2. Call our function as many times as we'd like via `Cape.invoke`.
+3. Close the connection with `Cape.close`
+
+```python
+cape = Cape(url=url)
+function_id = "iHWCTH2hWZ9tUAhAnQpwWL"
+function_hash = "8f0cf0cc7d4c6bdd6459d0be9cb090668f80f6a1313d3f4cfb97efb8ba80d6cb"
+function_ref = FunctionRef(function_id, function_hash)
+cape.connect(function_ref)
+low_list = [1, 2, 3, 4]
+result = cape.invoke(low_list, use_serdio=True)
+print(f"The mean is equal to: {result}")
+# The mean is equal to: 2.5
+
+high_list = [5, 6, 7, 8]
+result = cape.invoke(high_list, use_serdio=True)
+print(f"The mean is equal to: {result}")
+# The mean is equal to: 6.5
+
+result = cape.invoke(low_list + high_list, use_serdio=True)
+print(f"The mean is equal to: {result}")
+# The mean is equal to: 4.5
+
+
+result = cape.invoke([9, 10, 11, 12], use_serdio=True)
+print(f"The mean is equal to: {result}")
+# The mean is equal to: 10.5
+
+cape.close()
+```
+
+In fact, the `Cape.run` that we used before is simply a convenienc function rolling these three commands into one: `Cape.run` = `Cape.connect` + `Cape.invoke` + `Cape.close`.

--- a/pycape/__init__.py
+++ b/pycape/__init__.py
@@ -4,6 +4,6 @@ from pycape.function_ref import FunctionRef
 __version__ = "1.0.1-rc"
 
 __all__ = [
-    Cape,
-    FunctionRef,
+    "Cape",
+    "FunctionRef",
 ]

--- a/pycape/cape.py
+++ b/pycape/cape.py
@@ -6,7 +6,10 @@ function in Python and deploying it with the CLI, before being able to run it fr
 Cape client.
 
 Usage:
-    FUNCTION_ID = < given by CLI after `cape deploy` >
+
+::
+
+    FUNCTION_ID = "9712r5dynf57l1rcns2"
     cape = Cape(url="wss://enclave.capeprivacy.com")
     cape.connect(FUNCTION_ID)
 
@@ -17,6 +20,7 @@ Usage:
     print(c2)  # 13
 
     cape.close()  # release the websocket connection
+
 """
 
 import asyncio

--- a/pycape/function_ref.py
+++ b/pycape/function_ref.py
@@ -5,6 +5,9 @@ It is generally created from user-supplied metadata, which is given to the user
 as output of the Cape CLI's `deploy` command.
 
 Usage:
+
+::
+
     fid = "asdf231lkg1324afdg"
     fhash = str(b"2l1h21jhgb2k1jh3".hex())
     fref = FunctionRef(fid, fhash)

--- a/serdio/README.md
+++ b/serdio/README.md
@@ -6,7 +6,7 @@ Automatic serialization of function inputs and outputs using MessagePack.
 ## Why Serdio?
 Remotely executing Python code is complicated. A common pattern is to wrap the code into a function that maps serialized data to serialized data, however this leads to heavy amounts of boilerplate related to serialization of native and custom Python types.
 
-Serdio makes this easy by handling this serialization boilerplate for you as much as possible. For any custom types, it only requires the user to provide a encoder/decoder helpers that break the types down into Python-native components. An example can be found [below](#using-serdio-with-custom-types).
+Serdio makes this easy by handling this serialization boilerplate for you as much as possible. For any custom types, it only requires the user to provide a encoder/decoder helpers that break the types down into Python-native components. An example can be found <a href="#using-serdio-with-custom-types">below</a>.
 
 ## Installation
 
@@ -30,7 +30,7 @@ zbytes = my_cool_function(xyb_bytes)
 z = serdio.deserialize(zbytes)
 
 print(z)
->> 8.0
+# 8.0
 ```
 
 ### Using Serdio with Custom Types
@@ -77,12 +77,14 @@ def my_cool_function(a: MyCoolClass, b: float = 1.0) -> MyCoolResult:
     x: MyCoolResult = a.mul()
     return x.shift(b)
 
+my_handler = my_cool_function.as_bytes_handler()
+
 a = MyCoolClass(2, 3.0)
 ab_bytes = serdio.serialize(a, b=2.0, encoder=my_cool_function.encoder)
-c_bytes = handler(ab_bytes)
+c_bytes = my_handler(ab_bytes)
 c = serdio.deserialize(c_bytes, my_cool_function.decoder)
 
 assert c == my_cool_function(a, b=2.0)
 print(c.cool_result)
->> 8.0
+# 8.0
 ```

--- a/serdio/serdio/io_lifter.py
+++ b/serdio/serdio/io_lifter.py
@@ -6,22 +6,21 @@ executes the original function on those inputs, and then serializes outputs w/ m
 Custom types are handled by user-supplied encode_hook and decode_hook functions,
 bundled into a SerdeHookBundle dataclass.
 
-
-Basic usage in app.py:
+Basic usage in app.py: ::
 
     @serdio.lift_io(as_handler=True)
     def cape_handler(x: int, y: float) -> float:
         return x * y
 
-Then with Cape.run:
-    function_id = <noted during `cape deploy`>
+Then with Cape.run: ::
+
+    function_id = "1s25hd1s28f12"
     cape = Cape()
     z = cape.run(function_id, 2, 3.0, use_serdio=True)
     print(z)
-    >> 6.0
+    # 6.0
 
-
-Usage with custom types:
+Usage with custom types: ::
 
     @dataclasses.dataclass
     class MyCoolResult:
@@ -52,16 +51,15 @@ Usage with custom types:
                 return MyCoolResult(**obj["fields"])
         return obj
 
-
     @serdio.lift_io(encoder_hook=my_cool_encoder, decoder_hook=my_cool_decoder)
     def my_cool_function(x: MyCoolClass) -> MyCoolResult:
         return x.mul()
 
     cape_handler = my_cool_function.as_cape_handler()
 
-Then with Cape.run:
+Then with Cape.run: ::
 
-    my_cool_function_id = <noted during `cape deploy`>
+    my_cool_function_id = "9af98r1c52nt735yg"
     input = MyCoolClass(2, 3.0)  # input data we want to run with
 
     # the serde hook bundle, specifies how msgpack can deal w/ MyCoolClass/MyCoolResult
@@ -73,7 +71,7 @@ Then with Cape.run:
     cape = Cape()
     my_cool_result = cape.run(my_cool_function_id, input, serde_hooks=hook_bundle)
     print(my_cool_result.cool_result)
-    >> 6.0
+    # 6.0
 """
 import functools as ft
 import inspect


### PR DESCRIPTION
CAPE-896

The general process for adding documentation is:
- any changes to docstrings will automatically be reflected in the html generated by `make docs`, as long as they conform to the Google Docstring Style
- `docs/source/walkthrough.md` gives an example of a tutorial written in Markdown, which will be parsed by MyST for Sphinx
- any other general guides or tutorials can be added to `docs/source` as markdown file, and then included by name (without the .md extension) in the "Overview Docs" section of the `index.rst` file

Adds the following cmake targets for generating docs with Sphinx:
- `make install-docs`: installs docs dependencies, including `sphinx`, `myst-parser`, `sphinx-book-theme`
- `make docs-prep`: adds all source RST/Markdown files needed for Sphinx to generate docs to html
- `make docs`: use sphinx to generate html docs site
- `make docs-clean`: removes all files added by `docs-prep`