### PR TITLE
Add connection context manager

### DIFF
--- a/examples/invoke_echo.py
+++ b/examples/invoke_echo.py
@@ -15,15 +15,23 @@ if __name__ == "__main__":
         function_ref = FunctionRef(function_id, function_hash)
 
     cape = Cape(url=url, access_token=token)
-    cape.connect(function_ref)
 
+    cape.connect(function_ref)
     result = cape.invoke("Hello Cape".encode())
     print(f"The result is: {result.decode()}")
-
     result = cape.invoke("Hello Gavin".encode())
     print(f"The result is: {result.decode()}")
-
     result = cape.invoke("Hello Hello".encode())
     print(f"The result is: {result.decode()}")
-
     cape.close()
+
+    # Note that instead you can use the connection_context
+    # context manager which will automatically close the
+    # connection and reset websocket connection's states.
+    with cape.connection_context(function_ref):
+        result = cape.invoke("Hello Cape".encode())
+        print(f"The result is: {result.decode()}")
+        result = cape.invoke("Hello Gavin".encode())
+        print(f"The result is: {result.decode()}")
+        result = cape.invoke("Hello Hello".encode())
+        print(f"The result is: {result.decode()}")

--- a/examples/invoke_echo.py
+++ b/examples/invoke_echo.py
@@ -28,7 +28,7 @@ if __name__ == "__main__":
     # Note that instead you can use the connection_context
     # context manager which will automatically close the
     # connection and reset websocket connection's states.
-    with cape.connection_context(function_ref):
+    with cape.function_context(function_ref):
         result = cape.invoke("Hello Cape".encode())
         print(f"The result is: {result.decode()}")
         result = cape.invoke("Hello Gavin".encode())

--- a/pycape/cape.py
+++ b/pycape/cape.py
@@ -141,11 +141,8 @@ class Cape:
             Exception if the enclave threw an error while trying to fulfill the
                 connection request.
         """
-        function_ref = _convert_to_function_ref(function_ref)
         try:
-            yield self._loop.run_until_complete(
-                self._connect(function_ref, function_token)
-            )
+            yield self.connect(function_ref, function_token)
         finally:
             self._public_key = ""
             self._root_cert = None

--- a/pycape/cape.py
+++ b/pycape/cape.py
@@ -87,6 +87,8 @@ class Cape:
 
     def close(self):
         """Closes the enclave connection."""
+        self._public_key = ""
+        self._root_cert = None
         self._loop.run_until_complete(self._close())
 
     def connect(self, function_ref, function_token=None):
@@ -144,8 +146,6 @@ class Cape:
         try:
             yield self.connect(function_ref, function_token)
         finally:
-            self._public_key = ""
-            self._root_cert = None
             self.close()
 
     def invoke(self, *args, serde_hooks=None, use_serdio=False, **kwargs):

--- a/pycape/cape.py
+++ b/pycape/cape.py
@@ -119,7 +119,7 @@ class Cape:
         self._loop.run_until_complete(self._connect(function_ref, function_token))
 
     @contextlib.contextmanager
-    def connection_context(self, function_ref, function_token=None):
+    def function_context(self, function_ref, function_token=None):
         """Context manager to connect to the enclave hosting the function denoted
         by `function_ref`.
 

--- a/pycape/cape.py
+++ b/pycape/cape.py
@@ -25,6 +25,7 @@ Usage:
 
 import asyncio
 import base64
+import contextlib
 import dataclasses
 import enum
 import json
@@ -114,6 +115,41 @@ class Cape:
         """
         function_ref = _convert_to_function_ref(function_ref)
         self._loop.run_until_complete(self._connect(function_ref, function_token))
+
+    @contextlib.contextmanager
+    def connection_context(self, function_ref, function_token=None):
+        """Context manager to connect to the enclave hosting the function denoted
+        by `function_ref`.
+
+        Note that this context manager accomplishes the same functionality as
+        the connect method except it will automatically close the connection and
+        reset internal websocket connection's states when exiting the context.
+
+        Args:
+            function_ref: A function ID string or FunctionRef representing a deployed
+                Cape function. If a FunctionRef, can also include the function hash,
+                which  allows the user to verify that the enclave is hosting the same
+                function they deployed.
+            function_token: Optional string containing a Cape function token generated
+                by the Cape CLI during `cape token`. If None, the Cape access token
+                will be used instead.
+
+        Raises:
+            RuntimeError if the websocket response or the enclave attestation doc is
+                malformed, or if the enclave fails to return a function hash matching
+                our own.
+            Exception if the enclave threw an error while trying to fulfill the
+                connection request.
+        """
+        function_ref = _convert_to_function_ref(function_ref)
+        try:
+            yield self._loop.run_until_complete(
+                self._connect(function_ref, function_token)
+            )
+        finally:
+            self._public_key = ""
+            self._root_cert = None
+            self.close()
 
     def invoke(self, *args, serde_hooks=None, use_serdio=False, **kwargs):
         """Invokes a function call from the currently connected websocket.


### PR DESCRIPTION
[CAPE-805](https://capeprivacy.atlassian.net/browse/CAPE-805)

This pr add a `connection_context` method to Cape which returns a context manager. This context manager automatically closes and resets internal states when exiting. 