### PR TITLE
Add remaining missing type hints to Public API

### DIFF
--- a/serdio/serdio/io_lifter.py
+++ b/serdio/serdio/io_lifter.py
@@ -31,7 +31,12 @@ from serdio import serde
 
 
 def lift_io(
-    f=None, *, encoder_hook=None, decoder_hook=None, hook_bundle=None, as_handler=False
+    f: Callable = None,
+    *,
+    encoder_hook: Optional[Callable] = None,
+    decoder_hook: Optional[Callable] = None,
+    hook_bundle=None,
+    as_handler: bool = False,
 ):
     """Lift a function into an :class:`.IOLifter`.
 

--- a/serdio/serdio/serde.py
+++ b/serdio/serdio/serde.py
@@ -18,6 +18,7 @@ encoding/decoding of user-defined types.
 """
 import dataclasses
 import enum
+from typing import Any
 from typing import Callable
 from typing import Dict
 from typing import Tuple
@@ -125,7 +126,7 @@ def _msgpack_ext_unpack(code, data, custom_decoder=None):
     return msgpack.ExtType(code, data)
 
 
-def serialize(*args, encoder: Callable = None, **kwargs) -> bytes:
+def serialize(*args: Any, encoder: Callable = None, **kwargs: Any) -> bytes:
     """Serializes a set of ``args` and ``kwargs`` into bytes with MessagePack.
 
     Args:
@@ -159,7 +160,7 @@ def serialize(*args, encoder: Callable = None, **kwargs) -> bytes:
 
 def deserialize(
     serdio_bytes: bytes, decoder: Callable = None, as_signature: bool = False
-):
+) -> Any:
     """Unpacks serdio-serialized bytes to an object
 
     Args:


### PR DESCRIPTION
This PR completes https://github.com/capeprivacy/pycape/pull/76. For now we are adding type hints just to the public api which gets reflected in the documentation. 