### PR TITLE
add Cape.key command

### DIFF
--- a/pycape/cape.py
+++ b/pycape/cape.py
@@ -377,7 +377,8 @@ class Cape:
         attestation_doc = await key_ctx.bootstrap()
         await key_ctx.close()  # we have the attestation doc, no longer any need for ctx
         user_data = attestation_doc.get("user_data")
-        cape_key = user_data.get("cape_key")
+        user_data_dict = json.loads(user_data)
+        cape_key = user_data_dict.get("key")
         if cape_key is None:
             raise RuntimeError(
                 "Enclave response did not include a Cape key in attestation user data."


### PR DESCRIPTION
CAPE-963

adds the `Cape.key` command to load cape key from disk or download it from the `v1/key` route

tested against latest prod deploy