### PR TITLE
Add deploy

### DIFF
--- a/examples/deploy_run_echo.py
+++ b/examples/deploy_run_echo.py
@@ -1,33 +1,14 @@
-import subprocess
+import os
 
 from pycape import Cape
-from pycape import FunctionRef
 
-CAPE_HOST = "wss://enclave.capeprivacy.com"
+if __name__ == "__main__":
+    token = os.environ.get("CAPE_TOKEN", None)
+    url = os.environ.get("CAPE_HOST", "wss://enclave.capeprivacy.com")
 
-# Cape deploy function
-proc_deploy = subprocess.Popen(
-    "cape deploy ./echo --url " + CAPE_HOST,
-    shell=True,
-    stdout=subprocess.PIPE,
-    stderr=subprocess.PIPE,
-)
-out_deploy, err_deploy = proc_deploy.communicate()
-err_deploy = err_deploy.decode()
+    cape = Cape(url=url, access_token=token)
+    function_ref = cape.deploy("echo/")
+    input = "Welcome to Cape".encode()
+    result = cape.run(function_ref, input)
 
-# Parse stderr to get CAPE_FUNCTION_ID and CAPE_CHECKSUM
-err_deploy = err_deploy.split("\n")
-for i in err_deploy:
-    if "Function ID" in i:
-        function_id = i.split(" ")
-        CAPE_FUNCTION_ID = function_id[3]
-    elif "Checksum" in i:
-        checksum = i.split(" ")
-        CAPE_CHECKSUM = checksum[2]
-
-# Run function
-function_ref = FunctionRef(CAPE_FUNCTION_ID, CAPE_CHECKSUM)
-cape = Cape(url=CAPE_HOST)
-input = "Welcome to Cape".encode()
-result = cape.run(function_ref, input)
-print(f"The result is: {result.decode()}")
+    print(f"The result is: {result.decode()}")

--- a/examples/run_echo.py
+++ b/examples/run_echo.py
@@ -15,8 +15,6 @@ if __name__ == "__main__":
         function_ref = FunctionRef(function_id, checksum)
 
     cape = Cape(url=url, access_token=token)
-    function_ref = cape.deploy("echo/")
-    # function_ref = cape.deploy("zipped_function.zip")
     input = "Welcome to Cape".encode()
     result = cape.run(function_ref, input)
 

--- a/examples/run_echo.py
+++ b/examples/run_echo.py
@@ -15,6 +15,8 @@ if __name__ == "__main__":
         function_ref = FunctionRef(function_id, checksum)
 
     cape = Cape(url=url, access_token=token)
+    function_ref = cape.deploy("echo/")
+    # function_ref = cape.deploy("zipped_function.zip")
     input = "Welcome to Cape".encode()
     result = cape.run(function_ref, input)
 

--- a/pycape/_config.py
+++ b/pycape/_config.py
@@ -11,6 +11,7 @@ _CAPE_ENVVAR_DEFAULTS = {
     "LOCAL_AUTH_FILENAME": "auth",
     "LOCAL_CAPE_KEY_FILENAME": "capekey.pub.der",
     "LOCAL_CONFIG_DIR": str(pathlib.Path.home() / ".config" / "cape"),
+    "STORED_FUNCTION_MAX_BYTES": 1000000000,
 }
 
 

--- a/pycape/_token.py
+++ b/pycape/_token.py
@@ -1,0 +1,48 @@
+import pathlib
+
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+
+from pycape import _config as cape_config
+
+_FUNCTION_TOKEN_PUBLIC_KEY_FILE = "token.pub.pem"
+_FUNCTION_TOKEN_PRIVATE_KEY_FILE = "token.pem"
+
+
+def get_function_token_public_key_pem():
+    pubic_pem_file = (
+        pathlib.Path(cape_config.LOCAL_CONFIG_DIR) / _FUNCTION_TOKEN_PUBLIC_KEY_FILE
+    )
+
+    if not pubic_pem_file.is_file():
+        _ = _generate_rsa_key_pair()
+
+    with open(pubic_pem_file, "r") as f:
+        public_key_pem = f.read()
+
+    return public_key_pem
+
+
+def _generate_rsa_key_pair():
+    # Generate key pair
+    private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    public_key = private_key.public_key()
+
+    # Convert private key to PKCS#1
+    pem_private_key = private_key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.TraditionalOpenSSL,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+    # Convert public key to SubjectPublicKeyInfo
+    pem_public_key = public_key.public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+
+    pem_folder = pathlib.Path(cape_config.LOCAL_CONFIG_DIR)
+    with open(pem_folder / _FUNCTION_TOKEN_PRIVATE_KEY_FILE, "wb") as f:
+        f.write(pem_private_key)
+
+    with open(pem_folder / _FUNCTION_TOKEN_PUBLIC_KEY_FILE, "wb") as f:
+        f.write(pem_public_key)

--- a/pycape/cape.py
+++ b/pycape/cape.py
@@ -511,6 +511,8 @@ def _create_connection_request(nonce, token):
     """
     Returns a json string with nonce
     """
+    # TODO Remove auth token from initial request! Added temporarily
+    # because deploy requires it but it's a bug
     request = {"message": {"nonce": nonce, "auth_token": token}}
     return json.dumps(request)
 


### PR DESCRIPTION
CAPE-958

This PR had the following:
- Add deploy functionality as currently implemented in  cli/go sdk
- In aa separate PR we will add a token functionality to generate a function token. However, note that in this PR we have added a function to get the public key stored in `~/.config/cape/` or generate rsa key pair if it doesn't exist. The private key will be later used to sign the  function token, however the public needs to be sent during deploy so it can be used later to validate the function token. [Here](https://github.com/capeprivacy/cli/blob/2396637ac18be84e1a3802e76a59dfb59ca5435e/cmd/cape/cmd/deploy.go#L284) is the Go implementation as reference. 
- This PR has been tested against the demo environment with and without function token.
- Update the `deploy_run_echo.py` with this new functionality.