### PR TITLE
add Cape encrypt command

### DIFF
--- a/examples/deploy_run_echo.py
+++ b/examples/deploy_run_echo.py
@@ -1,13 +1,14 @@
+import pathlib
 import subprocess
 
-from pycape import Cape
-from pycape import FunctionRef
+import pycape
 
 CAPE_HOST = "wss://enclave.capeprivacy.com"
+ECHO_DEPLOY_PATH = pathlib.Path(__file__).parent.absolute() / "echo"
 
 # Cape deploy function
 proc_deploy = subprocess.Popen(
-    "cape deploy ./echo --url " + CAPE_HOST,
+    f"cape deploy {ECHO_DEPLOY_PATH} --url {CAPE_HOST}",
     shell=True,
     stdout=subprocess.PIPE,
     stderr=subprocess.PIPE,
@@ -17,17 +18,21 @@ err_deploy = err_deploy.decode()
 
 # Parse stderr to get CAPE_FUNCTION_ID and CAPE_CHECKSUM
 err_deploy = err_deploy.split("\n")
+function_id = function_checksum = None
 for i in err_deploy:
     if "Function ID" in i:
-        function_id = i.split(" ")
-        CAPE_FUNCTION_ID = function_id[3]
-    elif "Checksum" in i:
-        checksum = i.split(" ")
-        CAPE_CHECKSUM = checksum[2]
+        id_output = i.split(" ")
+        function_id = id_output[3]
+    elif "Function Checksum" in i:
+        checksum_output = i.split(" ")
+        function_checksum = checksum_output[2]
+
+if function_id is None:
+    raise RuntimeError(f"Function ID not found in 'deploy' response: \n{err_deploy}")
 
 # Run function
-function_ref = FunctionRef(CAPE_FUNCTION_ID, CAPE_CHECKSUM)
-cape = Cape(url=CAPE_HOST)
-input = "Welcome to Cape".encode()
-result = cape.run(function_ref, input)
+function_ref = pycape.FunctionRef(function_id, function_checksum)
+cape = pycape.Cape(url=CAPE_HOST)
+message = cape.encrypt("Welcome to Cape".encode())
+result = cape.run(function_ref, message)
 print(f"The result is: {result.decode()}")

--- a/pycape/_enclave_encrypt.py
+++ b/pycape/_enclave_encrypt.py
@@ -5,7 +5,7 @@ import hybrid_pke
 logger = logging.getLogger("pycape")
 
 
-def encrypt(public_key, input_bytes):
+def encrypt(public_key: bytes, input_bytes: bytes) -> bytes:
     logger.debug("* Encrypting inputs with Hybrid Public Key Encryption (HPKE)")
     hpke = hybrid_pke.default()
     info = b""

--- a/pycape/cape_encrypt.py
+++ b/pycape/cape_encrypt.py
@@ -1,0 +1,48 @@
+import os
+from typing import Tuple
+
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.asymmetric import padding
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.hazmat.primitives.ciphers import aead
+
+
+def encrypt(message: bytes, key: bytes) -> bytes:
+    # cape key is DEM-encoded RSA key
+    rsa_key = _parse_rsa_key(key)
+    # create ephemeral AES key
+    aes_key = _aes_keygen(32)
+    # encrypt message w/ AES
+    data_ctxt, nonce = _aes_encrypt(message)
+    # encrypt the ephemeral AES key w/ RSA
+    key_ctxt = _rsa_encrypt(aes_key, rsa_key)
+    # concatenate everything into a single bytes obj
+    final_ctxt = key_ctxt + nonce + data_ctxt
+    return final_ctxt
+
+
+def _aes_encrypt(inputs: bytes, key: bytes) -> Tuple[bytes, bytes]:
+    encryptor = aead.AESGCM(key)
+    nonce = os.urandom(12)  # AESGCM nonce size is 12
+    ctxt = encryptor.encrypt(nonce, inputs, None)
+    return ctxt, nonce
+
+
+def _aes_keygen(bitlength: int) -> bytes:
+    return aead.AESGCM.generate_aes_key(bitlength)
+
+
+def _parse_rsa_key(key: bytes) -> rsa.RSAPublicKey:
+    return x509.load_der_x609_certificate(key).public_key()
+
+
+def _rsa_encrypt(inputs: bytes, public_key: rsa.RSAPublicKey) -> bytes:
+    return public_key.encrypt(
+        inputs,
+        padding=padding.OAEP(
+            mgf=padding.MGF1(algorithm=hashes.SHA256()),
+            algorithm=hashes.SHA256(),
+            label=None,
+        ),
+    )

--- a/pycape/cape_encrypt.py
+++ b/pycape/cape_encrypt.py
@@ -1,3 +1,4 @@
+"""Utility functions supporting the Cape encrypt functionality."""
 import os
 from typing import Tuple
 
@@ -9,6 +10,25 @@ from cryptography.hazmat.primitives.ciphers import aead
 
 
 def encrypt(message: bytes, key: bytes) -> bytes:
+    """Encrypt a ``message`` with a Cape ``key``.
+
+    This function uses envelope encryption. The message is first AES-encrypted with an
+    ephemeral AES key, and then this key is itself encrypted with a given RSA public
+    key.
+
+    Args:
+        message: Bytes to encrypt.
+        key: Bytes representing the Cape key. Needs to be a valid, DEM-encoded RSA
+            public key.
+
+    Returns:
+        Bytes represeting the encryption of ``message``. The bytes are a concatenation
+        of the AES-ciphertext of ``message``, an AES nonce, and the RSA-ciphertext of
+        the AES key.
+
+    Raises:
+        ValueError: if the ``key`` is not a valid DEM-encoded RSA public key.
+    """
     # cape key is DEM-encoded RSA key
     rsa_key = _parse_rsa_key(key)
     # create ephemeral AES key

--- a/pycape/cape_encrypt.py
+++ b/pycape/cape_encrypt.py
@@ -1,8 +1,8 @@
 import os
 from typing import Tuple
 
-from cryptography import x509
 from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import padding
 from cryptography.hazmat.primitives.asymmetric import rsa
 from cryptography.hazmat.primitives.ciphers import aead
@@ -12,9 +12,9 @@ def encrypt(message: bytes, key: bytes) -> bytes:
     # cape key is DEM-encoded RSA key
     rsa_key = _parse_rsa_key(key)
     # create ephemeral AES key
-    aes_key = _aes_keygen(32)
+    aes_key = _aes_keygen(256)
     # encrypt message w/ AES
-    data_ctxt, nonce = _aes_encrypt(message)
+    data_ctxt, nonce = _aes_encrypt(message, aes_key)
     # encrypt the ephemeral AES key w/ RSA
     key_ctxt = _rsa_encrypt(aes_key, rsa_key)
     # concatenate everything into a single bytes obj
@@ -30,11 +30,16 @@ def _aes_encrypt(inputs: bytes, key: bytes) -> Tuple[bytes, bytes]:
 
 
 def _aes_keygen(bitlength: int) -> bytes:
-    return aead.AESGCM.generate_aes_key(bitlength)
+    return aead.AESGCM.generate_key(bitlength)
 
 
 def _parse_rsa_key(key: bytes) -> rsa.RSAPublicKey:
-    return x509.load_der_x609_certificate(key).public_key()
+    public_key = serialization.load_der_public_key(key)
+    if not isinstance(public_key, rsa.RSAPublicKey):
+        raise ValueError(
+            f"Decoded 'key' expected to be RSAPublicKey, found {type(public_key)}"
+        )
+    return public_key
 
 
 def _rsa_encrypt(inputs: bytes, public_key: rsa.RSAPublicKey) -> bytes:


### PR DESCRIPTION
adds the `encrypt` command to the Cape client, backed by the `cape_encrypt` module. this module may be refactored into a separate package in the near-future