### PR TITLE
Add cape deploy & token from cli

### DIFF
--- a/examples/async_echo.py
+++ b/examples/async_echo.py
@@ -1,43 +1,12 @@
 import asyncio
+import os
 import pathlib
-import subprocess
 
 import pycape
 
 
-def deploy_echo():
-    examples_dir = pathlib.Path(__file__).parent.absolute()
-    # Cape deploy function
-    proc_deploy = subprocess.Popen(
-        "cape deploy echo",
-        cwd=examples_dir,
-        shell=True,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-    )
-    _, err_deploy = proc_deploy.communicate()
-    err_deploy = err_deploy.decode()
-
-    # Parse stderr to get function id & function checksum
-    err_deploy = err_deploy.split("\n")
-    function_id = function_checksum = None
-    for i in err_deploy:
-        if "Function ID" in i:
-            id_output = i.split(" ")
-            function_id = id_output[3]
-        elif "Checksum" in i:
-            checksum_output = i.split(" ")
-            function_checksum = checksum_output[2]
-
-    if function_id is None:
-        raise RuntimeError(
-            f"Function ID not found in 'deploy' response: \n{err_deploy}"
-        )
-
-    return function_id, function_checksum
-
-
-async def main(cape: pycape.Cape, function_ref: pycape.FunctionRef, echo: str) -> str:
+async def main(cape: pycape.Cape, deploy_path: os.PathLike, echo: str) -> str:
+    function_ref = await cape.deploy(deploy_path)
     echo_arg = echo.encode()
     echo_enc = await cape.encrypt(echo_arg)
     async with cape.function_context(function_ref):
@@ -46,8 +15,8 @@ async def main(cape: pycape.Cape, function_ref: pycape.FunctionRef, echo: str) -
 
 
 if __name__ == "__main__":
+    echo_path = pathlib.Path(__file__).parent.absolute() / "echo"
+
     cape = pycape.Cape()
-    function_id, function_checksum = deploy_echo()
-    function_ref = pycape.FunctionRef(function_id, function_checksum)
-    echo = asyncio.run(main(cape, function_ref, "Welcome to Cape."))
+    echo = asyncio.run(main(cape, echo_path, "Welcome to Cape."))
     print(echo)

--- a/examples/async_echo.py
+++ b/examples/async_echo.py
@@ -3,10 +3,11 @@ import os
 import pathlib
 
 import pycape
+from pycape.experimental import cli
 
 
 async def main(cape: pycape.Cape, deploy_path: os.PathLike, echo: str) -> str:
-    function_ref = await cape.deploy(deploy_path)
+    function_ref = await cli.deploy(deploy_path)
     echo_arg = echo.encode()
     echo_enc = await cape.encrypt(echo_arg)
     async with cape.function_context(function_ref):

--- a/examples/deploy_run_echo.py
+++ b/examples/deploy_run_echo.py
@@ -9,6 +9,7 @@ ECHO_DEPLOY_PATH = pathlib.Path(__file__).parent.absolute() / "echo"
 cape = pycape.Cape(url=CAPE_HOST)
 # Deploy Cape function
 function_ref = cape.deploy(ECHO_DEPLOY_PATH)
+# function_ref = pycape.FunctionRef(id="jXScaKkrksFbVAWQidDAXY", token="eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJqWFNjYUtrcmtzRmJWQVdRaWREQVhZIiwiZXhwIjoxNjYzMjg3ODY4LCJpYXQiOjE2NjMyODQyNjh9.s7ZvMrSqPg_Oci3K4WngDbKYQ5slmRORxmd5S1aqwub0YWJcn-5aMoZbjS05uaXhvfLdaXDgzQ-SvJJRj5jhNpAYjXEBIXi-zPGDyqJJTA_ipy_4zMOqEEYDd4sKsszsDKatsNxg0Maxomzfhmxac-eI7o7Q4JPIiJHuAsn7e1iqYq3WbYW17E85lP9VIA8p3zQDlzBbeg0gwCuy8IctMlF0zj62WZ8exSnejdULY0v3YIQE2WfFnj38GHZTQYJqLfsgEYTlPDEkYkdlcUe5a6CXmdxwVLU7XFrHcui8jwqwH8P1Uc9A-WZoiIVNh1mLIcsuUugvWSuX0U914aL6Hg")
 message = cape.encrypt("Welcome to Cape".encode())
 # Run Cape function
 result = cape.run(function_ref, message)

--- a/examples/deploy_run_echo.py
+++ b/examples/deploy_run_echo.py
@@ -9,7 +9,6 @@ ECHO_DEPLOY_PATH = pathlib.Path(__file__).parent.absolute() / "echo"
 cape = pycape.Cape(url=CAPE_HOST)
 # Deploy Cape function
 function_ref = cape.deploy(ECHO_DEPLOY_PATH)
-# function_ref = pycape.FunctionRef(id="jXScaKkrksFbVAWQidDAXY", token="eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJqWFNjYUtrcmtzRmJWQVdRaWREQVhZIiwiZXhwIjoxNjYzMjg3ODY4LCJpYXQiOjE2NjMyODQyNjh9.s7ZvMrSqPg_Oci3K4WngDbKYQ5slmRORxmd5S1aqwub0YWJcn-5aMoZbjS05uaXhvfLdaXDgzQ-SvJJRj5jhNpAYjXEBIXi-zPGDyqJJTA_ipy_4zMOqEEYDd4sKsszsDKatsNxg0Maxomzfhmxac-eI7o7Q4JPIiJHuAsn7e1iqYq3WbYW17E85lP9VIA8p3zQDlzBbeg0gwCuy8IctMlF0zj62WZ8exSnejdULY0v3YIQE2WfFnj38GHZTQYJqLfsgEYTlPDEkYkdlcUe5a6CXmdxwVLU7XFrHcui8jwqwH8P1Uc9A-WZoiIVNh1mLIcsuUugvWSuX0U914aL6Hg")
 message = cape.encrypt("Welcome to Cape".encode())
 # Run Cape function
 result = cape.run(function_ref, message)

--- a/examples/deploy_run_echo.py
+++ b/examples/deploy_run_echo.py
@@ -1,6 +1,7 @@
 import pathlib
 
 import pycape
+from pycape.experimental import cli
 
 CAPE_HOST = "wss://enclave.capeprivacy.com"
 ECHO_DEPLOY_PATH = pathlib.Path(__file__).parent.absolute() / "echo"
@@ -8,7 +9,7 @@ ECHO_DEPLOY_PATH = pathlib.Path(__file__).parent.absolute() / "echo"
 
 cape = pycape.Cape(url=CAPE_HOST)
 # Deploy Cape function
-function_ref = cape.deploy(ECHO_DEPLOY_PATH)
+function_ref = cli.deploy(ECHO_DEPLOY_PATH)
 message = cape.encrypt("Welcome to Cape".encode())
 # Run Cape function
 result = cape.run(function_ref, message)

--- a/examples/deploy_run_echo.py
+++ b/examples/deploy_run_echo.py
@@ -1,38 +1,15 @@
 import pathlib
-import subprocess
 
 import pycape
 
 CAPE_HOST = "wss://enclave.capeprivacy.com"
 ECHO_DEPLOY_PATH = pathlib.Path(__file__).parent.absolute() / "echo"
 
-# Cape deploy function
-proc_deploy = subprocess.Popen(
-    f"cape deploy {ECHO_DEPLOY_PATH} --url {CAPE_HOST}",
-    shell=True,
-    stdout=subprocess.PIPE,
-    stderr=subprocess.PIPE,
-)
-out_deploy, err_deploy = proc_deploy.communicate()
-err_deploy = err_deploy.decode()
 
-# Parse stderr to get function id & function checksum
-err_deploy = err_deploy.split("\n")
-function_id = function_checksum = None
-for i in err_deploy:
-    if "Function ID" in i:
-        id_output = i.split(" ")
-        function_id = id_output[3]
-    elif "Checksum" in i:
-        checksum_output = i.split(" ")
-        function_checksum = checksum_output[2]
-
-if function_id is None:
-    raise RuntimeError(f"Function ID not found in 'deploy' response: \n{err_deploy}")
-
-# Run function
-function_ref = pycape.FunctionRef(function_id, function_checksum)
 cape = pycape.Cape(url=CAPE_HOST)
+# Deploy Cape function
+function_ref = cape.deploy(ECHO_DEPLOY_PATH)
 message = cape.encrypt("Welcome to Cape".encode())
+# Run Cape function
 result = cape.run(function_ref, message)
 print(f"The result is: {result.decode()}")

--- a/pycape/cape.py
+++ b/pycape/cape.py
@@ -387,9 +387,6 @@ class Cape:
                 )
         return
 
-    async def _close(self):
-        await self._ctx.close()
-
     async def _request_invocation(self, serde_hooks, use_serdio, *args, **kwargs):
         # If multiple args and/or kwargs are supplied to the Cape function through
         # Cape.run or Cape.invoke, before serialization, we pack them

--- a/pycape/cape.py
+++ b/pycape/cape.py
@@ -459,8 +459,13 @@ class Cape:
                 f"Function ID not found in 'deploy' response: \n{err_deploy}"
             )
 
-        function_token = await self._token(function_id)
-        # function_token = None
+        # TODO the function token should be set automatically with `self._token`.
+        # However we set it to None for now because if the input is encrypted
+        # with cape.encryp and the function is called with function token until
+        # this issue is completed: https://capeprivacy.atlassian.net/browse/CAPE-1004.
+        function_token = None
+        # function_token = await self._token(function_id)
+
         return fref.FunctionRef(function_id, function_checksum, function_token)
 
     async def _request_invocation(self, serde_hooks, use_serdio, *args, **kwargs):

--- a/pycape/cape.py
+++ b/pycape/cape.py
@@ -38,7 +38,6 @@ import os
 import pathlib
 import random
 import ssl
-import subprocess
 from typing import Any
 from typing import Dict
 from typing import List

--- a/pycape/experimental/cli.py
+++ b/pycape/experimental/cli.py
@@ -5,12 +5,9 @@ import subprocess
 from typing import Optional
 from typing import Union
 
-import synchronicity
-
 from pycape import _config as cape_config
 from pycape import function_ref as fref
-
-_synchronizer = synchronicity.Synchronizer(multiwrap_warning=True)
+from pycape.cape import _synchronizer
 
 
 @_synchronizer

--- a/pycape/experimental/cli.py
+++ b/pycape/experimental/cli.py
@@ -107,7 +107,7 @@ async def token(function_id, expires=None, url: Optional[str] = None):
     if expires:
         cmd_token = f"cape token {function_id} --expires {expires} -u {url}"
     else:
-        cmd_token = f"cape token {function_id} - u {url}"
+        cmd_token = f"cape token {function_id} -u {url}"
 
     out_token, err_token = _call_cape_cli(cmd_token)
     err_token = err_token.decode()

--- a/pycape/experimental/cli.py
+++ b/pycape/experimental/cli.py
@@ -1,0 +1,156 @@
+import os
+import pathlib
+import subprocess
+from typing import Optional
+from typing import Union
+
+import synchronicity
+
+from pycape import _config as cape_config
+from pycape import function_ref as fref
+
+_synchronizer = synchronicity.Synchronizer(multiwrap_warning=True)
+
+
+@_synchronizer
+async def deploy(
+    deploy_path: Union[str, os.PathLike], url: Optional[str] = None
+) -> fref.FunctionRef:
+    """Deploy a directory or a zip file containing a Cape function declared in
+    an app.py script.
+
+    This method calls `cape deploy` from the Cape CLI to deploy a Cape function
+    then returns a `~.function_ref.FunctionRef` representingthe the deployed
+    function.  Note that the ``deploy_path`` has to point to a directory or a
+    zip file containing a Cape function declared in an app.py file and the size
+    of its content  is currently limited to 1GB.
+
+    Args:
+        deploy_path: A path pointing to a directory or a zip file containing
+            a Cape function declared in an app.py script.
+        url: The Cape platform's websocket URL, which is responsible for forwarding
+            client requests to the proper enclave instances. If None, tries to load
+            value from the ``CAPE_ENCLAVE_HOST`` environment variable. If no such
+            variable value is supplied, defaults to ``"wss://enclave.capeprivacy.com"``.
+
+    Returns:
+        A :class:`~.function_ref.FunctionRef` representing the deployed Cape
+        function.
+
+    Raises:
+        RuntimeError: if the websocket response or the enclave attestation doc is
+            malformed, or if the function path is not pointing to a directory
+            or a zip file or if folder size exceeds 1GB, or if the Cape CLI cannot
+            be found on the device.
+    """
+    url = url or cape_config.ENCLAVE_HOST
+    deploy_path = pathlib.Path(deploy_path)
+    cmd_deploy = f"cape deploy {deploy_path} -u {url}"
+    _, err_deploy = _call_cape_cli(cmd_deploy)
+    err_deploy = err_deploy.decode()
+
+    # TODO refactor parsing once https://github.com/capeprivacy/cli/pull/185
+    # is part of a new release.
+    # Parse stderr to get function id & function checksum and potential error
+    err_deploy = err_deploy.split("\n")
+    error_output = function_id = function_checksum = None
+
+    for i in err_deploy:
+        if "Error" in i:
+            error_output = i
+            error_msg = error_output.partition("Error:")[2]
+            raise RuntimeError(f"Cape deploy error - {error_msg}")
+        if "Function ID" in i:
+            id_output = i.split(" ")
+            function_id = id_output[3]
+        elif "Checksum" in i:
+            checksum_output = i.split(" ")
+            function_checksum = checksum_output[2]
+
+    if function_id is None:
+        raise RuntimeError(
+            f"Function ID not found in 'cape.deploy' response: \n{err_deploy}"
+        )
+
+    # TODO the function token should be set automatically with `self._token`.
+    # However we set it to None for now because if the input is encrypted
+    # with cape.encryp and the function is called with function token until
+    # this issue is completed: https://capeprivacy.atlassian.net/browse/CAPE-1004.
+    function_token = None
+    # function_token = await token(function_id)
+
+    return fref.FunctionRef(function_id, function_checksum, function_token)
+
+
+async def token(function_id, expires=None, url: Optional[str] = None):
+    """Generate a function token (JSON Web Token) based on a function ID.
+
+    This method calls `cape token` from the Cape CLI to generate a function token
+    based on a function ID. Tokens can be created statically (long expiration and
+    bundled with your application) or created dynamically (short-lived) and have
+    an owner specified expiration. This function token is required in addition
+    to the function ID when calling a Cape function.
+
+    Args:
+        function_id: A function ID string representing a deployed Cape function.
+        exprires: Amount of time in seconds until the the function token expires.
+    url: The Cape platform's websocket URL, which is responsible for forwarding
+            client requests to the proper enclave instances. If None, tries to load
+            value from the ``CAPE_ENCLAVE_HOST`` environment variable. If no such
+            variable value is supplied, defaults to ``"wss://enclave.capeprivacy.com"``.
+
+    Returns:
+        A function token (JSON Web Token) as a string.
+
+        Raises:
+        RuntimeError: if the Cape CLI cannot be found on the device.
+    """
+    url = url or cape_config.ENCLAVE_HOST
+
+    if expires:
+        cmd_token = f"cape token {function_id} --expires {expires} -u {url}"
+    else:
+        cmd_token = f"cape token {function_id} - u {url}"
+
+    out_token, err_token = _call_cape_cli(cmd_token)
+    err_token = err_token.decode()
+    out_token = out_token.decode()
+
+    # Parse out_token to get function token
+    function_token = out_token.split("\n")[0]
+    err_deploy = err_token.split("\n")
+    error_output = None
+
+    # Parse err_token to get potential errors
+    for i in err_deploy:
+        if "Error" in i:
+            error_output = i
+            error_msg = error_output.partition("Error:")[2]
+            raise RuntimeError(f"Cape token error - {error_msg}")
+
+    if function_token is None:
+        raise RuntimeError(
+            f"Function token not found in 'cape.token' response: \n{err_deploy}"
+        )
+
+    return function_token
+
+
+def _check_if_cape_cli_available():
+    exitcode, output = subprocess.getstatusoutput("cape")
+    if exitcode != 0:
+        raise RuntimeError(
+            f"Please make sure Cape CLI is installed on your device: {output}"
+        )
+
+
+def _call_cape_cli(cape_cmd):
+    _check_if_cape_cli_available()
+    proc = subprocess.Popen(
+        cape_cmd,
+        shell=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    out, err = proc.communicate()
+    return out, err


### PR DESCRIPTION
CAPE-958

This pr add:
- `cape.deploy`: calls `cape deploy` from the cli to deploy Cape functions
- `cape.token`: calls `cape token` from the cli the generate function token.
- Update `async_echo.py` and `deploy_run_echo.py` examples to use `cape.deploy` instead of using subprocess manually.

I left two todos in this PR:
- We could refactor the parsing of the subprocess output once  this PR is part of the new cape release: https://github.com/capeprivacy/cli/pull/185
- Cape deploy currently returns a function reference without function token because as of now encrypted output (with cape.encrypt) doesn't get decrypted when the function gets called with function token. See conversation [here](https://capeprivacy.slack.com/archives/CU963S2C8/p1663334611424729?thread_ts=1663288675.696789&cid=CU963S2C8). Once [this jira ticket](https://capeprivacy.atlassian.net/browse/CAPE-1004) is closed, we can generate a function token as default.