### PR TITLE
add timeout error handling to Cape.invoke

### DIFF
--- a/pycape/cape.py
+++ b/pycape/cape.py
@@ -508,7 +508,15 @@ class _EnclaveContext:
         input_ciphertext = enclave_encrypt.encrypt(self._public_key, inputs)
 
         _logger.debug("> Sending encrypted inputs")
-        await self._websocket.send(input_ciphertext)
+        try:
+            await self._websocket.send(input_ciphertext)
+        except websockets.exceptions.ConnectionClosedOK:
+            raise RuntimeError(
+                "Enclave websocket connection was closed, likely due to timeout error. "
+                "Please invoke your function more frequently to keep the connection "
+                "alive for more than 60 seconds."
+            )
+
         invoke_response = await self._websocket.recv()
         _logger.debug("< Received function results")
 

--- a/pycape/cape.py
+++ b/pycape/cape.py
@@ -98,8 +98,9 @@ class Cape:
     @_synchronizer
     async def close(self):
         """Closes the current enclave connection."""
-        await self._ctx.close()
-        self._ctx = None
+        if self._ctx is not None:
+            await self._ctx.close()
+            self._ctx = None
 
     @_synchronizer
     async def connect(
@@ -501,7 +502,9 @@ class _EnclaveContext:
         return attestation_doc
 
     async def close(self):
-        await self._websocket.close()
+        if self._websocket is not None:
+            await self._websocket.close()
+            self._websocket = None
         self._public_key = None
 
     async def invoke(self, inputs: bytes) -> bytes:
@@ -511,6 +514,7 @@ class _EnclaveContext:
         try:
             await self._websocket.send(input_ciphertext)
         except websockets.exceptions.ConnectionClosedOK:
+            await self.close()
             raise RuntimeError(
                 "Enclave websocket connection was closed, likely due to timeout error. "
                 "Please invoke your function more frequently to keep the connection "


### PR DESCRIPTION
CAPE-920

handles a `ConnectionClosedOK` websocket exception in the case that the runtime timed out and gracefully closed the websocket connection