### PR TITLE
Properly verify cert chain

### DIFF
--- a/pycape/_attestation.py
+++ b/pycape/_attestation.py
@@ -63,12 +63,13 @@ def verify_cert_chain(root_cert, cabundle, cert):
 
     # Get the CA bundle from attestation document and store into X509Store
     # Except the first certificate, which is the root certificate
+    chain = []
     for _cert_binary in cabundle:
         _cert = crypto.load_certificate(crypto.FILETYPE_ASN1, _cert_binary)
-        store.add_cert(_cert)
+        chain.append(_cert)
 
     # Get the X509Store context
-    store_ctx = crypto.X509StoreContext(store, cert)
+    store_ctx = crypto.X509StoreContext(store, cert, chain=chain)
 
     # Validate the certificate
     # If the cert is invalid, it will raise exception

--- a/pycape/_attestation_test.py
+++ b/pycape/_attestation_test.py
@@ -1,13 +1,10 @@
 import base64
 import datetime
-import io
 import json
 import time
-import zipfile
 
 import cbor2
 import pytest
-import requests
 from cose.algorithms import Es384
 from cose.keys import EC2Key
 from cose.keys.curves import P384
@@ -51,6 +48,7 @@ cert_subject = x509.Name(
     ]
 )
 
+
 class TestAttestation:
     def test_parse_attestation(self):
         crv = P384
@@ -60,8 +58,12 @@ class TestAttestation:
         private_key = ec.generate_private_key(crv.curve_obj, backend=default_backend())
 
         root_cert = create_root_cert(root_private_key, root_subject)
-        intermediate_cert = create_child_cert(root_cert, root_private_key, root_private_key, intermediate_subject, ca=True)
-        cert = create_child_cert(intermediate_cert, root_private_key, private_key, cert_subject, ca=False)
+        intermediate_cert = create_child_cert(
+            root_cert, root_private_key, root_private_key, intermediate_subject, ca=True
+        )
+        cert = create_child_cert(
+            intermediate_cert, root_private_key, private_key, cert_subject, ca=False
+        )
         doc_bytes = create_attestation_doc(intermediate_cert, cert)
         attestation = create_cose_1_sign_msg(doc_bytes, private_key)
 
@@ -82,8 +84,12 @@ class TestAttestation:
         private_key = ec.generate_private_key(crv.curve_obj, backend=default_backend())
 
         root_cert = create_root_cert(root_private_key, root_subject)
-        intermediate_cert = create_child_cert(root_cert, root_private_key, root_private_key, intermediate_subject, ca=True)
-        cert = create_child_cert(intermediate_cert, root_private_key, private_key, cert_subject, ca=False)
+        intermediate_cert = create_child_cert(
+            root_cert, root_private_key, root_private_key, intermediate_subject, ca=True
+        )
+        cert = create_child_cert(
+            intermediate_cert, root_private_key, private_key, cert_subject, ca=False
+        )
         doc_bytes = create_attestation_doc(intermediate_cert, cert)
         attestation = create_cose_1_sign_msg(doc_bytes, private_key)
 
@@ -100,8 +106,12 @@ class TestAttestation:
         private_key = ec.generate_private_key(crv.curve_obj, backend=default_backend())
 
         root_cert = create_root_cert(root_private_key, root_subject)
-        intermediate_cert = create_child_cert(root_cert, root_private_key, root_private_key, intermediate_subject, ca=True)
-        cert = create_child_cert(intermediate_cert, root_private_key, private_key, cert_subject)
+        intermediate_cert = create_child_cert(
+            root_cert, root_private_key, root_private_key, intermediate_subject, ca=True
+        )
+        cert = create_child_cert(
+            intermediate_cert, root_private_key, private_key, cert_subject
+        )
 
         doc_bytes = create_attestation_doc(intermediate_cert, cert)
         attestation = create_cose_1_sign_msg(doc_bytes, private_key)
@@ -113,19 +123,24 @@ class TestAttestation:
 
         attest.verify_cert_chain(root_cert_pem, doc["cabundle"], doc["certificate"])
 
-
     def test_verify_cert_chain_fails_if_bad_intermediate(self):
         crv = P384
         root_private_key = ec.generate_private_key(
             crv.curve_obj, backend=default_backend()
         )
-        intermediate_private_key = ec.generate_private_key(crv.curve_obj, backend=default_backend())
+        intermediate_private_key = ec.generate_private_key(
+            crv.curve_obj, backend=default_backend()
+        )
 
         private_key = ec.generate_private_key(crv.curve_obj, backend=default_backend())
 
         root_cert = create_root_cert(root_private_key, root_subject)
-        intermediate_cert = create_root_cert(intermediate_private_key, intermediate_subject)
-        cert = create_child_cert(intermediate_cert, root_private_key, private_key, cert_subject, ca=False)
+        intermediate_cert = create_root_cert(
+            intermediate_private_key, intermediate_subject
+        )
+        cert = create_child_cert(
+            intermediate_cert, root_private_key, private_key, cert_subject, ca=False
+        )
 
         doc_bytes = create_attestation_doc(intermediate_cert, cert)
         attestation = create_cose_1_sign_msg(doc_bytes, private_key)
@@ -138,7 +153,6 @@ class TestAttestation:
         with pytest.raises(crypto.X509StoreContextError):
             attest.verify_cert_chain(root_cert_pem, doc["cabundle"], doc["certificate"])
 
-
     def test_verify_pcrs(self):
         crv = P384
         root_private_key = ec.generate_private_key(
@@ -147,8 +161,12 @@ class TestAttestation:
         private_key = ec.generate_private_key(crv.curve_obj, backend=default_backend())
 
         root_cert = create_root_cert(root_private_key, root_subject)
-        intermediate_cert = create_child_cert(root_cert, root_private_key, root_private_key, intermediate_subject, ca=True)
-        cert = create_child_cert(intermediate_cert, root_private_key, private_key, cert_subject, ca=False)
+        intermediate_cert = create_child_cert(
+            root_cert, root_private_key, root_private_key, intermediate_subject, ca=True
+        )
+        cert = create_child_cert(
+            intermediate_cert, root_private_key, private_key, cert_subject, ca=False
+        )
         doc_bytes = create_attestation_doc(intermediate_cert, cert)
         attestation = create_cose_1_sign_msg(doc_bytes, private_key)
 
@@ -166,8 +184,12 @@ class TestAttestation:
         private_key = ec.generate_private_key(crv.curve_obj, backend=default_backend())
 
         root_cert = create_root_cert(root_private_key, root_subject)
-        intermediate_cert = create_child_cert(root_cert, root_private_key, root_private_key, intermediate_subject, ca=True)
-        cert = create_child_cert(intermediate_cert, root_private_key, private_key, cert_subject, ca=False)
+        intermediate_cert = create_child_cert(
+            root_cert, root_private_key, root_private_key, intermediate_subject, ca=True
+        )
+        cert = create_child_cert(
+            intermediate_cert, root_private_key, private_key, cert_subject, ca=False
+        )
         doc_bytes = create_attestation_doc(intermediate_cert, cert)
         attestation = create_cose_1_sign_msg(doc_bytes, private_key)
 
@@ -249,7 +271,9 @@ def create_child_cert(parent_cert, parent_key, cert_key, subject, ca=False):
     )
 
     if ca:
-        builder = builder.add_extension(x509.BasicConstraints(ca=True, path_length=None), critical=True)
+        builder = builder.add_extension(
+            x509.BasicConstraints(ca=True, path_length=None), critical=True
+        )
 
     cert = builder.sign(parent_key, hashes.SHA256(), default_backend())
 

--- a/pycape/_attestation_test.py
+++ b/pycape/_attestation_test.py
@@ -18,9 +18,38 @@ from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.asymmetric import ec
 from cryptography.hazmat.primitives.serialization import Encoding
 from cryptography.x509.oid import NameOID
+from OpenSSL import crypto
 
 from pycape import _attestation as attest
 
+root_subject = issuer = x509.Name(
+    [
+        x509.NameAttribute(NameOID.COUNTRY_NAME, "US"),
+        x509.NameAttribute(NameOID.STATE_OR_PROVINCE_NAME, "Texas"),
+        x509.NameAttribute(NameOID.LOCALITY_NAME, "Austin"),
+        x509.NameAttribute(NameOID.ORGANIZATION_NAME, "My Company"),
+        x509.NameAttribute(NameOID.COMMON_NAME, "My CA"),
+    ]
+)
+
+intermediate_subject = issuer = x509.Name(
+    [
+        x509.NameAttribute(NameOID.COUNTRY_NAME, "JP"),
+        x509.NameAttribute(NameOID.STATE_OR_PROVINCE_NAME, "Tokyo"),
+        x509.NameAttribute(NameOID.LOCALITY_NAME, "Tokyo"),
+        x509.NameAttribute(NameOID.ORGANIZATION_NAME, "Cool Comp"),
+        x509.NameAttribute(NameOID.COMMON_NAME, "COOL"),
+    ]
+)
+
+cert_subject = x509.Name(
+    [
+        x509.NameAttribute(NameOID.COUNTRY_NAME, "CA"),
+        x509.NameAttribute(NameOID.STATE_OR_PROVINCE_NAME, "Nova Scotia"),
+        x509.NameAttribute(NameOID.LOCALITY_NAME, "Halifax"),
+        x509.NameAttribute(NameOID.ORGANIZATION_NAME, "New Org Name!"),
+    ]
+)
 
 class TestAttestation:
     def test_parse_attestation(self):
@@ -30,8 +59,10 @@ class TestAttestation:
         )
         private_key = ec.generate_private_key(crv.curve_obj, backend=default_backend())
 
-        root_cert, cert = create_certs(root_private_key, private_key)
-        doc_bytes = create_attestation_doc(root_cert, cert)
+        root_cert = create_root_cert(root_private_key, root_subject)
+        intermediate_cert = create_child_cert(root_cert, root_private_key, root_private_key, intermediate_subject, ca=True)
+        cert = create_child_cert(intermediate_cert, root_private_key, private_key, cert_subject, ca=False)
+        doc_bytes = create_attestation_doc(intermediate_cert, cert)
         attestation = create_cose_1_sign_msg(doc_bytes, private_key)
 
         attestation_doc = attest.parse_attestation(
@@ -50,8 +81,10 @@ class TestAttestation:
         )
         private_key = ec.generate_private_key(crv.curve_obj, backend=default_backend())
 
-        root_cert, cert = create_certs(root_private_key, private_key)
-        doc_bytes = create_attestation_doc(root_cert, cert)
+        root_cert = create_root_cert(root_private_key, root_subject)
+        intermediate_cert = create_child_cert(root_cert, root_private_key, root_private_key, intermediate_subject, ca=True)
+        cert = create_child_cert(intermediate_cert, root_private_key, private_key, cert_subject, ca=False)
+        doc_bytes = create_attestation_doc(intermediate_cert, cert)
         attestation = create_cose_1_sign_msg(doc_bytes, private_key)
 
         payload = cbor2.loads(attestation)
@@ -66,21 +99,45 @@ class TestAttestation:
         )
         private_key = ec.generate_private_key(crv.curve_obj, backend=default_backend())
 
-        root_cert, cert = create_certs(root_private_key, private_key)
-        doc_bytes = create_attestation_doc(root_cert, cert)
+        root_cert = create_root_cert(root_private_key, root_subject)
+        intermediate_cert = create_child_cert(root_cert, root_private_key, root_private_key, intermediate_subject, ca=True)
+        cert = create_child_cert(intermediate_cert, root_private_key, private_key, cert_subject)
+
+        doc_bytes = create_attestation_doc(intermediate_cert, cert)
         attestation = create_cose_1_sign_msg(doc_bytes, private_key)
 
         payload = cbor2.loads(attestation)
         doc = cbor2.loads(payload[2])
 
-        url = "https://aws-nitro-enclaves.amazonaws.com/AWS_NitroEnclaves_Root-G1.zip"
-        r = requests.get(url)
+        root_cert_pem = root_cert.public_bytes(Encoding.PEM)
 
-        f = zipfile.ZipFile(io.BytesIO(r.content))
-        with f.open("root.pem") as p:
-            root_cert = p.read()
+        attest.verify_cert_chain(root_cert_pem, doc["cabundle"], doc["certificate"])
 
-        attest.verify_cert_chain(root_cert, doc["cabundle"], doc["certificate"])
+
+    def test_verify_cert_chain_fails_if_bad_intermediate(self):
+        crv = P384
+        root_private_key = ec.generate_private_key(
+            crv.curve_obj, backend=default_backend()
+        )
+        intermediate_private_key = ec.generate_private_key(crv.curve_obj, backend=default_backend())
+
+        private_key = ec.generate_private_key(crv.curve_obj, backend=default_backend())
+
+        root_cert = create_root_cert(root_private_key, root_subject)
+        intermediate_cert = create_root_cert(intermediate_private_key, intermediate_subject)
+        cert = create_child_cert(intermediate_cert, root_private_key, private_key, cert_subject, ca=False)
+
+        doc_bytes = create_attestation_doc(intermediate_cert, cert)
+        attestation = create_cose_1_sign_msg(doc_bytes, private_key)
+
+        payload = cbor2.loads(attestation)
+        doc = cbor2.loads(payload[2])
+
+        root_cert_pem = root_cert.public_bytes(Encoding.PEM)
+
+        with pytest.raises(crypto.X509StoreContextError):
+            attest.verify_cert_chain(root_cert_pem, doc["cabundle"], doc["certificate"])
+
 
     def test_verify_pcrs(self):
         crv = P384
@@ -89,8 +146,10 @@ class TestAttestation:
         )
         private_key = ec.generate_private_key(crv.curve_obj, backend=default_backend())
 
-        root_cert, cert = create_certs(root_private_key, private_key)
-        doc_bytes = create_attestation_doc(root_cert, cert)
+        root_cert = create_root_cert(root_private_key, root_subject)
+        intermediate_cert = create_child_cert(root_cert, root_private_key, root_private_key, intermediate_subject, ca=True)
+        cert = create_child_cert(intermediate_cert, root_private_key, private_key, cert_subject, ca=False)
+        doc_bytes = create_attestation_doc(intermediate_cert, cert)
         attestation = create_cose_1_sign_msg(doc_bytes, private_key)
 
         attestation_doc = attest.parse_attestation(
@@ -106,8 +165,10 @@ class TestAttestation:
         )
         private_key = ec.generate_private_key(crv.curve_obj, backend=default_backend())
 
-        root_cert, cert = create_certs(root_private_key, private_key)
-        doc_bytes = create_attestation_doc(root_cert, cert)
+        root_cert = create_root_cert(root_private_key, root_subject)
+        intermediate_cert = create_child_cert(root_cert, root_private_key, root_private_key, intermediate_subject, ca=True)
+        cert = create_child_cert(intermediate_cert, root_private_key, private_key, cert_subject, ca=False)
+        doc_bytes = create_attestation_doc(intermediate_cert, cert)
         attestation = create_cose_1_sign_msg(doc_bytes, private_key)
 
         attestation_doc = attest.parse_attestation(
@@ -140,9 +201,9 @@ def create_cose_1_sign_msg(payload, private_key):
     return msg.encode(tag=False)
 
 
-def create_attestation_doc(root_cert, cert):
+def create_attestation_doc(intermediate_cert, cert):
     cert = cert.public_bytes(Encoding.DER)
-    root_cert = root_cert.public_bytes(Encoding.DER)
+    intermediate_cert = intermediate_cert.public_bytes(Encoding.DER)
     user_data = json.dumps({"func_hash": "stuff"})
     public_key = base64.b64decode("d4Y4fxNr/hga+d86m2Lw+SXu+QO6Uuk3yrtrS9CoVgI=")
     obj = {
@@ -151,7 +212,7 @@ def create_attestation_doc(root_cert, cert):
         "digest": "abcd",
         "pcrs": {0: b"pcrpcrpcr"},
         "certificate": cert,
-        "cabundle": [root_cert],
+        "cabundle": [intermediate_cert],
         "public_key": public_key,
         "user_data": user_data,
     }
@@ -159,16 +220,8 @@ def create_attestation_doc(root_cert, cert):
     return cbor2.encoder.dumps(obj)
 
 
-def create_certs(root_key, cert_key):
-    subject = issuer = x509.Name(
-        [
-            x509.NameAttribute(NameOID.COUNTRY_NAME, "US"),
-            x509.NameAttribute(NameOID.STATE_OR_PROVINCE_NAME, "Texas"),
-            x509.NameAttribute(NameOID.LOCALITY_NAME, "Austin"),
-            x509.NameAttribute(NameOID.ORGANIZATION_NAME, "My Company"),
-            x509.NameAttribute(NameOID.COMMON_NAME, "My CA"),
-        ]
-    )
+def create_root_cert(root_key, subject):
+    issuer = subject
     root_cert = (
         x509.CertificateBuilder()
         .subject_name(subject)
@@ -181,27 +234,23 @@ def create_certs(root_key, cert_key):
         .sign(root_key, hashes.SHA256(), default_backend())
     )
 
-    new_subject = x509.Name(
-        [
-            x509.NameAttribute(NameOID.COUNTRY_NAME, "US"),
-            x509.NameAttribute(NameOID.STATE_OR_PROVINCE_NAME, "Texas"),
-            x509.NameAttribute(NameOID.LOCALITY_NAME, "Austin"),
-            x509.NameAttribute(NameOID.ORGANIZATION_NAME, "New Org Name!"),
-        ]
-    )
-    cert = (
+    return root_cert
+
+
+def create_child_cert(parent_cert, parent_key, cert_key, subject, ca=False):
+    builder = (
         x509.CertificateBuilder()
-        .subject_name(new_subject)
-        .issuer_name(root_cert.issuer)
+        .subject_name(subject)
+        .issuer_name(parent_cert.issuer)
         .public_key(cert_key.public_key())
         .serial_number(x509.random_serial_number())
         .not_valid_before(datetime.datetime.utcnow())
         .not_valid_after(datetime.datetime.utcnow() + datetime.timedelta(days=30))
-        .add_extension(
-            x509.SubjectAlternativeName([x509.DNSName("somedomain.com")]),
-            critical=False,
-        )
-        .sign(root_key, hashes.SHA256(), default_backend())
     )
 
-    return root_cert, cert
+    if ca:
+        builder = builder.add_extension(x509.BasicConstraints(ca=True, path_length=None), critical=True)
+
+    cert = builder.sign(parent_key, hashes.SHA256(), default_backend())
+
+    return cert

--- a/pycape/_enclave_encrypt_test.py
+++ b/pycape/_enclave_encrypt_test.py
@@ -1,12 +1,5 @@
-from cose.keys.curves import P384
-from cryptography.hazmat.backends import default_backend
-from cryptography.hazmat.primitives.asymmetric import ec
-from cryptography.hazmat.primitives.serialization import Encoding
+import base64
 
-from pycape._attestation import parse_attestation
-from pycape._attestation_test import create_attestation_doc
-from pycape._attestation_test import create_certs
-from pycape._attestation_test import create_cose_1_sign_msg
 from pycape._enclave_encrypt import encrypt
 
 
@@ -14,18 +7,6 @@ class TestEnclaveEncryption:
     def test_data_encryption(self):
         plaintext = b"private_data"
 
-        crv = P384
-        root_private_key = ec.generate_private_key(
-            crv.curve_obj, backend=default_backend()
-        )
-        private_key = ec.generate_private_key(crv.curve_obj, backend=default_backend())
+        public_key = base64.b64decode("d4Y4fxNr/hga+d86m2Lw+SXu+QO6Uuk3yrtrS9CoVgI=")
 
-        root_cert, cert = create_certs(root_private_key, private_key)
-        doc_bytes = create_attestation_doc(root_cert, cert)
-        attestation = create_cose_1_sign_msg(doc_bytes, private_key)
-
-        attestation_doc = parse_attestation(
-            attestation, root_cert.public_bytes(Encoding.PEM)
-        )
-        public_key = attestation_doc["public_key"]
         _ = encrypt(public_key, plaintext)


### PR DESCRIPTION
Before we were passing the intermediate certs in ca_bundle in the x509 store. This store is meant for trusted certs only. We can pass additional certs to the chain parameter to help build and verify the chains.