### PR TITLE
Revert "cape_encrypt bump version 0.1.0 -> 0.1.1"

### DIFF
--- a/cape_encrypt/.bumpversion.cfg
+++ b/cape_encrypt/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.1.1
+current_version = 0.1.0
 commit = True
 tag = True
 sign_tags = True

--- a/cape_encrypt/cape_encrypt/__init__.py
+++ b/cape_encrypt/cape_encrypt/__init__.py
@@ -1,7 +1,7 @@
 from cape_encrypt.cape_encrypt import decrypt
 from cape_encrypt.cape_encrypt import encrypt
 
-__version__ = "0.1.1"
+__version__ = "0.1.0"
 
 __all__ = [
     "encrypt",

--- a/cape_encrypt/pyproject.toml
+++ b/cape_encrypt/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "cape_encrypt"
 description = "Encryption aid for functions running in Cape Enclaves"
 readme = "README.md"
-version = "0.1.1"
+version = "0.1.0"
 requires-python = ">=3.7"
 authors = [
     {email = "contact@capeprivacy.com", name = "Cape Privacy"}


### PR DESCRIPTION
This reverts commit 8d69c3b7079edfacc4c2040931af4c0dafa7b40e. To allow for the corrected tag cut for this version. 