### PR TITLE
fix docsite logo and missing cape_encrypt api ref

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,6 +69,9 @@ bump-major: bump-prep
 .PHONY: install-docs
 install-docs:
 	pip install -U sphinx myst-parser sphinx-book-theme sphinx-copybutton sphinx-autodoc-typehints
+	pip install -U sphinx-book-theme~=0.3
+	pip install -U sphinx~=5.0
+	pip install ./cape_encrypt/
 
 .PHONY: docs-clean
 docs-clean:

--- a/cape_encrypt/cape_encrypt/cape_encrypt.py
+++ b/cape_encrypt/cape_encrypt/cape_encrypt.py
@@ -48,14 +48,14 @@ def encrypt(plaintext: bytes) -> bytes:
     Returns:
         Bytes representing the base64 encoded encryption of the ``plaintext``. The
         bytes are a concatenation of the AES-ciphertext of the ``plaintext``, an AES
-        nonce, and the RSA-ciphertext of the AES key prefixed by ``cape:``.
+        nonce, and the RSA-ciphertext of the AES key prefixed by ``b"cape:"``
 
     Raises:
         TypeError: if the input is not of the correct type
         ValueError: if the input is empty
         ConnectionError: if an error is thrown from the socket connection
         ExecutionError: if a server error is reported during the remote encryption
-        process
+            process
     """
     if not isinstance(plaintext, (bytes, bytearray)):
         raise TypeError("input is required to be valid bytes")
@@ -83,7 +83,7 @@ def decrypt(ciphertext: bytes) -> bytes:
 
     Args:
         b64ciphertext: Base64 encoded bytes of a previously Cape Encrypted plaintext,
-        prefixed with Cape:
+            prefixed with ``b"cape:"``
 
     Returns:
         Bytes represeting the plaintext result of the decrypted ciphertext
@@ -93,7 +93,7 @@ def decrypt(ciphertext: bytes) -> bytes:
         ValueError: if the input is formatted incorrectly or empty
         ConnectionError: if an error is thrown from the socket connection
         ExecutionError: if a server error is reported during the remote encryption
-        process
+            process
     """
     prefix = b"cape:"
     if not isinstance(ciphertext, (bytes, bytearray)):


### PR DESCRIPTION
Most of the issues were related to outdated sphinx dependencies -- somehow the pip dependency resolver finds that the only compatible configuration of our dependencies pins to very old versions of sphinx and the sphinx-book-theme layout. We force upgrade sphinx and sphinx-book-theme, which moves the dependencies into an "impossible resolution" according to pip. Haven't observed any issues with this approach, so perhaps we aren't using any major api shifts from sphinx4 to sphinx5. This fixes the broken logo issue.

The other issue was resolved by installing `cape_encrypt` as a dependency for building docs