### PR TITLE
bump cryptography to resolve security alert

### DIFF
--- a/requirements/base.in
+++ b/requirements/base.in
@@ -2,9 +2,8 @@ cbor2
 hybrid_pke~=1.0
 file:./serdio
 websockets
-pyOpenSSL
+pyOpenSSL>=22.1.0
 cose
 certifi>=2022.12.07
-cryptography>=39.0.1
 requests
 synchronicity

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -5,5 +5,6 @@ websockets
 pyOpenSSL
 cose
 certifi>=2022.12.07
+cryptography>=39.0.1
 requests
 synchronicity

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -26,8 +26,9 @@ charset-normalizer==2.1.0
     # via requests
 cose==0.9.dev8
     # via -r requirements/base.in
-cryptography==38.0.3
+cryptography==39.0.1
     # via
+    #   -r requirements/base.in
     #   cose
     #   pyopenssl
 ecdsa==0.18.0

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -28,7 +28,6 @@ cose==0.9.dev8
     # via -r requirements/base.in
 cryptography==39.0.1
     # via
-    #   -r requirements/base.in
     #   cose
     #   pyopenssl
 ecdsa==0.18.0
@@ -43,7 +42,7 @@ oscrypto==1.3.0
     # via certvalidator
 pycparser==2.21
     # via cffi
-pyopenssl==22.0.0
+pyopenssl==23.0.0
     # via -r requirements/base.in
 requests==2.28.1
     # via -r requirements/base.in


### PR DESCRIPTION
there's a [minor security alert](https://github.com/advisories/GHSA-w7pp-m8wf-vj6r) in the `cryptography` package that doesn't affect us, but it will be good to get rid of before the next release.

turns out pyOpenSSL<22.1.0 has conflict with cryptography>39.0.0, so the correct way to fix the alert is to bump pyOpenSSL, which I've done here