### PR TITLE
Limit synchronicity dependency < 0.3.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
     "cose",
     "requests",
     "serdio",
-    "synchronicity",
+    "synchronicity < 0.3.0",
 ]
 authors = [
     {email = "contact@capeprivacy.com", name = "Cape Privacy"}


### PR DESCRIPTION
Limit synchronicity dependency < 0.3.0 because of the API changes in >= 0.3.0.